### PR TITLE
feat: PDF preview and markdown editor for resume uploads

### DIFF
--- a/prisma/migrations/20260410163248_add_pdf_data/migration.sql
+++ b/prisma/migrations/20260410163248_add_pdf_data/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Resume" ADD COLUMN     "pdfData" BYTEA;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,7 @@ model Resume {
   id        String   @id @default(cuid())
   filename  String
   content   String
+  pdfData   Bytes?
   createdAt DateTime @default(now())
   jobs      Job[]
 }

--- a/src/app/api/resume/[id]/pdf/route.ts
+++ b/src/app/api/resume/[id]/pdf/route.ts
@@ -1,0 +1,28 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const resume = await prisma.resume.findUnique({
+    where: { id },
+    select: { pdfData: true },
+  });
+
+  if (!resume?.pdfData) {
+    return NextResponse.json({ error: "PDF not found" }, { status: 404 });
+  }
+
+  return new NextResponse(resume.pdfData, {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": "inline",
+      "Cache-Control": "private, max-age=3600",
+    },
+  });
+}

--- a/src/app/api/resume/parse/route.ts
+++ b/src/app/api/resume/parse/route.ts
@@ -1,0 +1,29 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+// pdf-parse is CJS-only; use require to avoid ESM default-export issues
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const pdfParse = require("pdf-parse") as (buf: Buffer) => Promise<{ text: string }>;
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+  const file = formData.get("file") as File | null;
+
+  if (!file) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  const bytes = await file.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+
+  let content: string;
+
+  if (file.type === "application/pdf" || file.name.endsWith(".pdf")) {
+    const parsed = await pdfParse(buffer);
+    content = parsed.text;
+  } else {
+    content = buffer.toString("utf-8");
+  }
+
+  return NextResponse.json({ content });
+}

--- a/src/app/api/resume/route.ts
+++ b/src/app/api/resume/route.ts
@@ -2,41 +2,57 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-// pdf-parse is CJS-only; use require to avoid ESM default-export issues
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const pdfParse = require("pdf-parse") as (buf: Buffer) => Promise<{ text: string }>;
 
 export async function GET() {
   const resume = await prisma.resume.findFirst({
     orderBy: { createdAt: "desc" },
-    select: { id: true, filename: true, content: true, createdAt: true },
+    select: { id: true, filename: true, content: true, createdAt: true, pdfData: true },
   });
-  return NextResponse.json(resume ?? null);
+
+  if (!resume) return NextResponse.json(null);
+
+  return NextResponse.json({
+    id: resume.id,
+    filename: resume.filename,
+    content: resume.content,
+    createdAt: resume.createdAt,
+    hasPdf: resume.pdfData !== null,
+  });
 }
 
 export async function POST(req: NextRequest) {
   const formData = await req.formData();
   const file = formData.get("file") as File | null;
+  const content = formData.get("content") as string | null;
 
   if (!file) {
     return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+  if (!content) {
+    return NextResponse.json({ error: "No content provided" }, { status: 400 });
   }
 
   const bytes = await file.arrayBuffer();
   const buffer = Buffer.from(bytes);
 
-  let content: string;
-
-  if (file.type === "application/pdf" || file.name.endsWith(".pdf")) {
-    const parsed = await pdfParse(buffer);
-    content = parsed.text;
-  } else {
-    content = buffer.toString("utf-8");
-  }
+  const isPdf = file.type === "application/pdf" || file.name.endsWith(".pdf");
 
   const resume = await prisma.resume.create({
-    data: { filename: file.name, content },
+    data: {
+      filename: file.name,
+      content,
+      pdfData: isPdf ? buffer : null,
+    },
   });
 
-  return NextResponse.json(resume, { status: 201 });
+  return NextResponse.json(
+    {
+      id: resume.id,
+      filename: resume.filename,
+      content: resume.content,
+      createdAt: resume.createdAt,
+      hasPdf: resume.pdfData !== null,
+    },
+    { status: 201 }
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ interface Resume {
   filename: string;
   content: string;
   createdAt: string;
+  hasPdf: boolean;
 }
 
 interface Job {

--- a/src/components/resume/ResumeSection.tsx
+++ b/src/components/resume/ResumeSection.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import { Upload, FileText, Loader2 } from "lucide-react";
 
 interface Resume {
@@ -10,6 +17,7 @@ interface Resume {
   filename: string;
   content: string;
   createdAt: string;
+  hasPdf: boolean;
 }
 
 interface ResumeSectionProps {
@@ -17,103 +25,235 @@ interface ResumeSectionProps {
   onUpload: (resume: Resume) => void;
 }
 
+type Stage =
+  | { name: "idle" }
+  | { name: "parsing"; file: File }
+  | { name: "editing"; file: File; content: string; blobUrl: string }
+  | { name: "saving" };
+
 export function ResumeSection({ resume, onUpload }: ResumeSectionProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [uploading, setUploading] = useState(false);
+  const [stage, setStage] = useState<Stage>({ name: "idle" });
   const [error, setError] = useState("");
+  const [editedContent, setEditedContent] = useState("");
+
+  // Clean up blob URL when editing stage is exited
+  useEffect(() => {
+    return () => {
+      if (stage.name === "editing") {
+        URL.revokeObjectURL(stage.blobUrl);
+      }
+    };
+  }, [stage]);
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
 
+    if (fileInputRef.current) fileInputRef.current.value = "";
+
     setError("");
-    setUploading(true);
+    setStage({ name: "parsing", file });
+
     try {
       const formData = new FormData();
       formData.append("file", file);
 
-      const res = await fetch("/api/resume", { method: "POST", body: formData });
-      if (!res.ok) {
-        throw new Error("Upload failed");
-      }
-      const data = await res.json();
-      onUpload(data);
+      const res = await fetch("/api/resume/parse", { method: "POST", body: formData });
+      if (!res.ok) throw new Error("Parse failed");
+
+      const { content } = await res.json();
+      const isPdf = file.type === "application/pdf" || file.name.endsWith(".pdf");
+      const blobUrl = isPdf ? URL.createObjectURL(file) : "";
+
+      setEditedContent(content);
+      setStage({ name: "editing", file, content, blobUrl });
     } catch {
-      setError("Failed to upload resume. Please try again.");
-    } finally {
-      setUploading(false);
-      // Reset input so same file can be re-uploaded
-      if (fileInputRef.current) fileInputRef.current.value = "";
+      setError("Failed to parse file. Please try again.");
+      setStage({ name: "idle" });
     }
   }
 
+  function handleCancel() {
+    if (stage.name === "editing") {
+      URL.revokeObjectURL(stage.blobUrl);
+    }
+    setStage({ name: "idle" });
+    setError("");
+  }
+
+  async function handleSave() {
+    if (stage.name !== "editing") return;
+
+    const { file, blobUrl } = stage;
+    setStage({ name: "saving" });
+
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("content", editedContent);
+
+      const res = await fetch("/api/resume", { method: "POST", body: formData });
+      if (!res.ok) throw new Error("Upload failed");
+
+      const data: Resume = await res.json();
+      URL.revokeObjectURL(blobUrl);
+      onUpload(data);
+      setStage({ name: "idle" });
+    } catch {
+      setError("Failed to save resume. Please try again.");
+      setStage({ name: "editing", file, content: editedContent, blobUrl });
+    }
+  }
+
+  const isParsing = stage.name === "parsing";
+  const isSaving = stage.name === "saving";
+  const isEditing = stage.name === "editing";
+  const editingFile = isEditing ? (stage as { name: "editing"; file: File; content: string; blobUrl: string }) : null;
+  const isPdf = editingFile
+    ? editingFile.file.type === "application/pdf" || editingFile.file.name.endsWith(".pdf")
+    : false;
+
   return (
-    <Card className="h-full">
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base flex items-center justify-between">
-          <span className="flex items-center gap-2">
-            <FileText className="h-4 w-4" />
-            Resume
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={uploading}
-            className="text-xs"
-          >
-            {uploading ? (
-              <><Loader2 className="h-3 w-3 animate-spin" /> Uploading...</>
-            ) : (
-              <><Upload className="h-3 w-3" /> {resume ? "Replace" : "Upload"}</>
-            )}
-          </Button>
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".pdf,.txt,.md"
-          className="hidden"
-          onChange={handleFileChange}
-        />
+    <>
+      <Card className="h-full">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center justify-between">
+            <span className="flex items-center gap-2">
+              <FileText className="h-4 w-4" />
+              Resume
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isParsing || isSaving}
+              className="text-xs"
+            >
+              {isParsing ? (
+                <><Loader2 className="h-3 w-3 animate-spin" /> Parsing...</>
+              ) : (
+                <><Upload className="h-3 w-3" /> {resume ? "Replace" : "Upload"}</>
+              )}
+            </Button>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".pdf,.txt,.md"
+            className="hidden"
+            onChange={handleFileChange}
+          />
 
-        {error && <p className="text-xs text-red-500 mb-2">{error}</p>}
+          {error && <p className="text-xs text-red-500 mb-2">{error}</p>}
 
-        {resume ? (
-          <div
-            className="cursor-pointer group"
-            onClick={() => fileInputRef.current?.click()}
-            title="Click to replace resume"
-          >
-            <p className="text-xs text-slate-500 mb-2 font-medium group-hover:text-slate-700 transition-colors">
-              {resume.filename}
-              <span className="ml-2 text-slate-300">·</span>
-              <span className="ml-2 text-slate-400">
-                {new Date(resume.createdAt).toLocaleDateString()}
-              </span>
-            </p>
-            <div className="h-48 overflow-hidden rounded border border-slate-100 bg-slate-50 p-3 group-hover:border-slate-300 transition-colors">
-              <p className="text-xs text-slate-600 whitespace-pre-wrap leading-relaxed font-mono">
-                {resume.content.slice(0, 800)}
-                {resume.content.length > 800 && (
-                  <span className="text-slate-400">…</span>
-                )}
+          {resume ? (
+            <div
+              className="cursor-pointer group"
+              onClick={() => fileInputRef.current?.click()}
+              title="Click to replace resume"
+            >
+              <p className="text-xs text-slate-500 mb-2 font-medium group-hover:text-slate-700 transition-colors">
+                {resume.filename}
+                <span className="ml-2 text-slate-300">·</span>
+                <span className="ml-2 text-slate-400">
+                  {new Date(resume.createdAt).toLocaleDateString()}
+                </span>
               </p>
+              <div className="h-64 overflow-hidden rounded border border-slate-100 bg-slate-50 group-hover:border-slate-300 transition-colors">
+                {resume.hasPdf ? (
+                  <iframe
+                    src={`/api/resume/${resume.id}/pdf`}
+                    className="w-full h-full"
+                    title={resume.filename}
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                ) : (
+                  <p className="text-xs text-slate-600 whitespace-pre-wrap leading-relaxed font-mono p-3">
+                    {resume.content.slice(0, 800)}
+                    {resume.content.length > 800 && (
+                      <span className="text-slate-400">…</span>
+                    )}
+                  </p>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div
+              className="flex flex-col items-center justify-center h-48 border-2 border-dashed border-slate-200 rounded-lg cursor-pointer hover:border-slate-400 hover:bg-slate-50 transition-colors"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Upload className="h-8 w-8 text-slate-300 mb-2" />
+              <p className="text-sm text-slate-500">Upload your resume</p>
+              <p className="text-xs text-slate-400 mt-1">PDF or plain text</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={isEditing} onOpenChange={(open) => { if (!open) handleCancel(); }}>
+        <DialogContent className="max-w-5xl h-[85vh] flex flex-col gap-0 p-0">
+          <DialogHeader className="px-6 py-4 border-b border-slate-200 shrink-0">
+            <DialogTitle className="text-base">
+              Review Resume — {editingFile?.file.name}
+            </DialogTitle>
+            <p className="text-xs text-slate-500 mt-1">
+              Verify the extracted text below. Edit the markdown to correct any parsing errors before saving.
+            </p>
+          </DialogHeader>
+
+          <div className="flex flex-1 min-h-0 divide-x divide-slate-200">
+            {/* PDF preview panel */}
+            <div className="w-1/2 flex flex-col min-h-0">
+              <p className="text-xs font-medium text-slate-500 px-4 py-2 border-b border-slate-100 shrink-0">
+                Original PDF
+              </p>
+              <div className="flex-1 min-h-0">
+                {isPdf && editingFile?.blobUrl ? (
+                  <iframe
+                    src={editingFile.blobUrl}
+                    className="w-full h-full"
+                    title="PDF preview"
+                  />
+                ) : (
+                  <div className="flex items-center justify-center h-full text-slate-400 text-sm">
+                    No PDF preview available
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Markdown editor panel */}
+            <div className="w-1/2 flex flex-col min-h-0">
+              <p className="text-xs font-medium text-slate-500 px-4 py-2 border-b border-slate-100 shrink-0">
+                Extracted text (markdown)
+              </p>
+              <textarea
+                className="flex-1 min-h-0 resize-none p-4 text-xs font-mono text-slate-700 bg-white focus:outline-none"
+                value={editedContent}
+                onChange={(e) => setEditedContent(e.target.value)}
+                spellCheck={false}
+                placeholder="Extracted resume text will appear here…"
+              />
             </div>
           </div>
-        ) : (
-          <div
-            className="flex flex-col items-center justify-center h-48 border-2 border-dashed border-slate-200 rounded-lg cursor-pointer hover:border-slate-400 hover:bg-slate-50 transition-colors"
-            onClick={() => fileInputRef.current?.click()}
-          >
-            <Upload className="h-8 w-8 text-slate-300 mb-2" />
-            <p className="text-sm text-slate-500">Upload your resume</p>
-            <p className="text-xs text-slate-400 mt-1">PDF or plain text</p>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+
+          <DialogFooter className="px-6 py-4 border-t border-slate-200 shrink-0">
+            <Button variant="ghost" onClick={handleCancel} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={isSaving || !editedContent.trim()}>
+              {isSaving ? (
+                <><Loader2 className="h-4 w-4 animate-spin mr-2" /> Saving…</>
+              ) : (
+                "Save Resume"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
- Store original PDF binary (pdfData Bytes?) in the Resume model
- Add POST /api/resume/parse to extract text without saving, enabling a two-step upload flow
- Add GET /api/resume/[id]/pdf to serve the stored PDF binary inline
- Update POST /api/resume to accept user-edited content and store pdfData; GET returns a hasPdf boolean instead of the raw bytes
- ResumeSection now opens a full-screen dialog after file selection, showing the original PDF on the left and an editable markdown textarea on the right so users can verify and correct parsed text before saving
- Saved resume card shows an iframe PDF preview when pdfData is available, falling back to the text preview for legacy records

https://claude.ai/code/session_01HKd2RaXD6AeuT1vyeQbfu9