### PR TITLE
Add company merging, last-applied fallback date, and improved sort order

### DIFF
--- a/src/app/api/companies/[id]/merge/route.ts
+++ b/src/app/api/companies/[id]/merge/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { MergeCompanySchema } from "@/lib/schemas";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const body = await req.json();
+  const parsed = MergeCompanySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { targetId } = parsed.data;
+
+  if (id === targetId) {
+    return NextResponse.json({ error: "Cannot merge a company into itself" }, { status: 400 });
+  }
+
+  // Verify both companies exist
+  const { data: source, error: sourceError } = await supabase
+    .from("companies")
+    .select("id, name")
+    .eq("id", id)
+    .single();
+
+  if (sourceError || !source) {
+    return NextResponse.json({ error: "Source company not found" }, { status: 404 });
+  }
+
+  const { data: target, error: targetError } = await supabase
+    .from("companies")
+    .select("id, name")
+    .eq("id", targetId)
+    .single();
+
+  if (targetError || !target) {
+    return NextResponse.json({ error: "Target company not found" }, { status: 404 });
+  }
+
+  // Reassign all jobs from source to target
+  const { error: jobsError } = await supabase
+    .from("jobs")
+    .update({ company_id: targetId })
+    .eq("company_id", id);
+
+  if (jobsError) {
+    return NextResponse.json({ error: jobsError.message }, { status: 500 });
+  }
+
+  // Delete the source company
+  const { error: deleteError } = await supabase
+    .from("companies")
+    .delete()
+    .eq("id", id);
+
+  if (deleteError) {
+    return NextResponse.json({ error: deleteError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, targetId });
+}

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -3,26 +3,64 @@ import { supabase } from "@/lib/supabase";
 import { CreateCompanySchema } from "@/lib/schemas";
 
 export async function GET() {
-  const { data, error } = await supabase
-    .from("companies")
-    .select("*")
-    .order("name", { ascending: true });
+  const [{ data, error }, { data: appliedRows }] = await Promise.all([
+    supabase.from("companies").select("*"),
+    supabase
+      .from("jobs")
+      .select("company_id, date_applied")
+      .is("deleted_at", null)
+      .not("company_id", "is", null)
+      .not("date_applied", "is", null)
+      .order("date_applied", { ascending: false }),
+  ]);
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  return NextResponse.json(
-    (data ?? []).map((c) => ({
-      id: c.id,
-      name: c.name,
-      site: c.site,
-      jobListingIndex: c.job_listing_index,
-      lastCheckedAt: c.last_checked_at,
-      createdAt: c.created_at,
-      updatedAt: c.updated_at,
-    }))
-  );
+  // Build map of company_id -> most recent date_applied
+  const lastAppliedMap: Record<string, string> = {};
+  for (const row of appliedRows ?? []) {
+    if (row.company_id && !lastAppliedMap[row.company_id]) {
+      lastAppliedMap[row.company_id] = row.date_applied;
+    }
+  }
+
+  type CompanyRow = {
+    id: string;
+    name: string;
+    site: string | null;
+    job_listing_index: string | null;
+    last_checked_at: string | null;
+    created_at: string;
+    updated_at: string;
+  };
+
+  const companies = (data as CompanyRow[] ?? []).map((c) => ({
+    id: c.id,
+    name: c.name,
+    site: c.site,
+    jobListingIndex: c.job_listing_index,
+    lastCheckedAt: c.last_checked_at,
+    lastAppliedAt: lastAppliedMap[c.id] ?? null,
+    createdAt: c.created_at,
+    updatedAt: c.updated_at,
+  }));
+
+  type MappedCompany = (typeof companies)[number];
+
+  // Sort: no effective date first (oldest first otherwise)
+  // Effective date = lastCheckedAt ?? lastAppliedAt
+  companies.sort((a: MappedCompany, b: MappedCompany) => {
+    const da = a.lastCheckedAt ?? a.lastAppliedAt;
+    const db = b.lastCheckedAt ?? b.lastAppliedAt;
+    if (!da && !db) return a.name.localeCompare(b.name);
+    if (!da) return -1;
+    if (!db) return 1;
+    return new Date(da).getTime() - new Date(db).getTime();
+  });
+
+  return NextResponse.json(companies);
 }
 
 export async function POST(req: NextRequest) {

--- a/src/components/companies/CompaniesSection.tsx
+++ b/src/components/companies/CompaniesSection.tsx
@@ -12,6 +12,7 @@ interface Company {
   site: string | null;
   jobListingIndex: string | null;
   lastCheckedAt: string | null;
+  lastAppliedAt: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -64,56 +65,70 @@ export function CompaniesSection() {
         </div>
       ) : (
         <div className="space-y-1">
-          {companies.map((company) => (
-            <div
-              key={company.id}
-              className="flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg hover:bg-muted/50 group"
-            >
-              <div className="flex items-center gap-2 min-w-0">
-                <CompanyEditDialog company={company} onSaved={refresh} />
-                {company.jobListingIndex && (
-                  <a
-                    href={company.jobListingIndex}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-muted-foreground hover:text-foreground shrink-0"
-                    title="Open job listings"
+          {companies.map((company) => {
+            const otherCompanies = companies
+              .filter((c) => c.id !== company.id)
+              .map((c) => ({ id: c.id, name: c.name }));
+
+            return (
+              <div
+                key={company.id}
+                className="flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg hover:bg-muted/50 group"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <CompanyEditDialog
+                    company={company}
+                    otherCompanies={otherCompanies}
+                    onSaved={refresh}
+                  />
+                  {company.jobListingIndex && (
+                    <a
+                      href={company.jobListingIndex}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-muted-foreground hover:text-foreground shrink-0"
+                      title="Open job listings"
+                    >
+                      <ExternalLink className="h-3.5 w-3.5" />
+                    </a>
+                  )}
+                  {company.site && !company.jobListingIndex && (
+                    <a
+                      href={company.site}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-muted-foreground hover:text-foreground shrink-0"
+                      title="Open company website"
+                    >
+                      <ExternalLink className="h-3.5 w-3.5" />
+                    </a>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  {company.lastCheckedAt ? (
+                    <span className="text-xs text-muted-foreground">
+                      checked {new Date(company.lastCheckedAt).toLocaleDateString()}
+                    </span>
+                  ) : company.lastAppliedAt ? (
+                    <span className="text-xs text-muted-foreground/60">
+                      applied {new Date(company.lastAppliedAt).toLocaleDateString()}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground/50">never checked</span>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+                    title="Mark checked today"
+                    onClick={() => handleMarkChecked(company.id)}
                   >
-                    <ExternalLink className="h-3.5 w-3.5" />
-                  </a>
-                )}
-                {company.site && !company.jobListingIndex && (
-                  <a
-                    href={company.site}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-muted-foreground hover:text-foreground shrink-0"
-                    title="Open company website"
-                  >
-                    <ExternalLink className="h-3.5 w-3.5" />
-                  </a>
-                )}
+                    <Clock className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
               </div>
-              <div className="flex items-center gap-2 shrink-0">
-                {company.lastCheckedAt ? (
-                  <span className="text-xs text-muted-foreground">
-                    checked {new Date(company.lastCheckedAt).toLocaleDateString()}
-                  </span>
-                ) : (
-                  <span className="text-xs text-muted-foreground/50">never checked</span>
-                )}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
-                  title="Mark checked today"
-                  onClick={() => handleMarkChecked(company.id)}
-                >
-                  <Clock className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/companies/CompanyEditDialog.tsx
+++ b/src/components/companies/CompanyEditDialog.tsx
@@ -13,6 +13,14 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 
 interface Company {
   id: string;
@@ -24,10 +32,11 @@ interface Company {
 
 interface CompanyEditDialogProps {
   company: Company;
+  otherCompanies: { id: string; name: string }[];
   onSaved: () => void;
 }
 
-export function CompanyEditDialog({ company, onSaved }: CompanyEditDialogProps) {
+export function CompanyEditDialog({ company, otherCompanies, onSaved }: CompanyEditDialogProps) {
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -37,6 +46,8 @@ export function CompanyEditDialog({ company, onSaved }: CompanyEditDialogProps) 
   const [lastCheckedAt, setLastCheckedAt] = useState(
     company.lastCheckedAt ? company.lastCheckedAt.slice(0, 10) : ""
   );
+  const [mergeTargetId, setMergeTargetId] = useState<string>("");
+  const [merging, setMerging] = useState(false);
 
   function handleOpenChange(value: boolean) {
     if (value) {
@@ -44,6 +55,7 @@ export function CompanyEditDialog({ company, onSaved }: CompanyEditDialogProps) 
       setSite(company.site ?? "");
       setJobListingIndex(company.jobListingIndex ?? "");
       setLastCheckedAt(company.lastCheckedAt ? company.lastCheckedAt.slice(0, 10) : "");
+      setMergeTargetId("");
       setError(null);
     }
     setOpen(value);
@@ -76,6 +88,29 @@ export function CompanyEditDialog({ company, onSaved }: CompanyEditDialogProps) 
       setError(err instanceof Error ? err.message : "Failed to save");
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleMerge() {
+    if (!mergeTargetId) return;
+    setMerging(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/companies/${company.id}/merge`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetId: mergeTargetId }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? "Failed to merge");
+      }
+      onSaved();
+      setOpen(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to merge");
+    } finally {
+      setMerging(false);
     }
   }
 
@@ -127,13 +162,48 @@ export function CompanyEditDialog({ company, onSaved }: CompanyEditDialogProps) 
               onChange={(e) => setLastCheckedAt(e.target.value)}
             />
           </div>
+
+          {otherCompanies.length > 0 && (
+            <>
+              <Separator />
+              <div className="space-y-1.5">
+                <Label htmlFor="merge-target">Merge into another company</Label>
+                <p className="text-xs text-muted-foreground">
+                  All jobs from <span className="font-medium">{company.name}</span> will be moved to the selected company, then this entry will be deleted.
+                </p>
+                <div className="flex gap-2">
+                  <Select value={mergeTargetId} onValueChange={setMergeTargetId}>
+                    <SelectTrigger className="flex-1">
+                      <SelectValue placeholder="Select company…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {otherCompanies.map((c) => (
+                        <SelectItem key={c.id} value={c.id}>
+                          {c.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    variant="destructive"
+                    onClick={handleMerge}
+                    disabled={!mergeTargetId || merging}
+                  >
+                    {merging && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+                    Merge
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+
           {error && <p className="text-sm text-red-500">{error}</p>}
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => setOpen(false)} disabled={saving}>
+          <Button variant="outline" onClick={() => setOpen(false)} disabled={saving || merging}>
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={saving || !name.trim()}>
+          <Button onClick={handleSave} disabled={saving || merging || !name.trim()}>
             {saving && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
             Save
           </Button>

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -88,6 +88,11 @@ export const UpdateCompanySchema = z.object({
 });
 export type UpdateCompanyInput = z.infer<typeof UpdateCompanySchema>;
 
+export const MergeCompanySchema = z.object({
+  targetId: z.string().uuid("Must be a valid company ID"),
+});
+export type MergeCompanyInput = z.infer<typeof MergeCompanySchema>;
+
 // ─── AI: Generate ─────────────────────────────────────────────────────────────
 
 export const GenerateRequestSchema = z.object({


### PR DESCRIPTION
- New POST /api/companies/[id]/merge endpoint reassigns all jobs from
  the source company to a target, then deletes the source
- MergeCompanySchema added to validate the targetId
- GET /api/companies now fetches the most recent date_applied per
  company and exposes it as lastAppliedAt; used as fallback when
  lastCheckedAt is null
- Company list sorted: no effective date (no checks + no applications)
  floats to top, then oldest effective date (lastCheckedAt ?? lastAppliedAt)
  first; ties broken alphabetically
- CompanyEditDialog gains a "Merge into" section with a Select dropdown
  and Merge button; only shown when other companies exist
- CompaniesSection passes the filtered companies list to each dialog
  and displays "applied {date}" label when lastCheckedAt is absent

https://claude.ai/code/session_01Ya8PFvjZiwUjdX8Q8grC7j