### PR TITLE
Use Claude Agent SDK to drive job ingest with enriched extraction and cost tracking

### DIFF
--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -19,6 +19,19 @@ function mapJob(job: Record<string, unknown>) {
     updatedAt: job.updated_at,
     resume: job.resume,
     sessionId: job.session_id,
+    companyWebsite: job.company_website ?? null,
+    companySummary: job.company_summary ?? null,
+    workStyle: job.work_style ?? null,
+    requiredSkills: job.required_skills ?? null,
+    preferredSkills: job.preferred_skills ?? null,
+    primaryLanguages: job.primary_languages ?? null,
+    frameworks: job.frameworks ?? null,
+    roleClassification: job.role_classification ?? null,
+    positionSummary: job.position_summary ?? null,
+    compensation: job.compensation ?? null,
+    benefits: job.benefits ?? null,
+    flags: job.flags ?? null,
+    claudeCostUsd: job.claude_cost_usd ?? 0,
     statusLogs: ((job.status_logs as unknown[]) ?? []).map((l: unknown) => {
       const log = l as Record<string, unknown>;
       return { id: log.id, status: log.status, note: log.note, createdAt: log.created_at };

--- a/src/app/api/jobs/[id]/scrape/route.ts
+++ b/src/app/api/jobs/[id]/scrape/route.ts
@@ -1,29 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { spawn } from "child_process";
-import { chromium } from "playwright";
 import { supabase } from "@/lib/supabase";
 import { parseJob } from "@/lib/claude";
 import { matchOrCreateCompanyByName } from "@/lib/company-matching";
 
-async function runDecant(html: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const proc = spawn("decant", ["clean"], { env: { ...process.env, PATH: process.env.PATH + ":/usr/local/bin:/home/root/.local/bin" } });
-    let out = "";
-    let err = "";
-    proc.stdout.on("data", (d) => (out += d.toString()));
-    proc.stderr.on("data", (d) => (err += d.toString()));
-    proc.on("close", (code) => {
-      if (code === 0) resolve(out);
-      else reject(new Error(`decant exited ${code}: ${err}`));
-    });
-    proc.on("error", reject);
-    proc.stdin.write(html);
-    proc.stdin.end();
-  });
-}
-
 async function resolveCompanyId(jobId: string, extractedName: string | null | undefined): Promise<string | null> {
-  // If job already has a company_id (from URL matching at creation), preserve it
   const { data: currentJob } = await supabase
     .from("jobs")
     .select("company_id")
@@ -32,49 +12,52 @@ async function resolveCompanyId(jobId: string, extractedName: string | null | un
 
   if (currentJob?.company_id) return currentJob.company_id;
 
-  // Otherwise match or create by extracted name
   return matchOrCreateCompanyByName(extractedName);
 }
 
-async function extractAndUpdate(id: string, html: string) {
-  // 1. Clean HTML to markdown
-  let markdown = html;
-  try {
-    markdown = await runDecant(html);
-  } catch {
-    // decant not available, strip tags and fall back to plain text
-    markdown = html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim().slice(0, 20000);
-  }
+async function runExtraction(id: string, input: { url: string } | { html: string }) {
+  const { data: extracted, sessionId, costUsd } = await parseJob(input);
 
-  // 2. Save full description so we can re-run extraction without re-scraping
-  await supabase.from("jobs").update({ description_full: markdown }).eq("id", id);
-  await supabase.from("status_logs").insert({
-    job_id: id,
-    status: "RESEARCHING",
-    note: "Full description scraped",
-  });
-
-  // 3. Extract structured data via Claude Agent SDK
-  const { data: extracted, sessionId } = await parseJob(markdown.slice(0, 15000));
-
-  // 4. Resolve company_id (preserve existing URL match, or match/create by name)
   const companyId = await resolveCompanyId(id, extracted.company);
 
-  // 5. Update job with structured fields, session_id, and advance status
+  // Fetch current cost to accumulate
+  const { data: currentJob } = await supabase
+    .from("jobs")
+    .select("claude_cost_usd, company_id")
+    .eq("id", id)
+    .single();
+
+  const accumulatedCost = (currentJob?.claude_cost_usd ?? 0) + costUsd;
+
   await supabase
     .from("jobs")
     .update({
-      company_id: companyId,
+      company_id: currentJob?.company_id ?? companyId,
       title: extracted.title,
       description: extracted.description,
+      description_full: extracted.fullJobPostingHtml ?? ("html" in input ? input.html : null),
       session_id: sessionId,
       status: "PENDING_APPLICATION",
+      company_website: extracted.companyWebsite ?? null,
+      company_summary: extracted.companySummary ?? null,
+      work_style: extracted.workStyle ?? null,
+      required_skills: extracted.requiredSkills ?? null,
+      preferred_skills: extracted.preferredSkills ?? null,
+      primary_languages: extracted.primaryLanguages ?? null,
+      frameworks: extracted.frameworks ?? null,
+      role_classification: extracted.roleClassification ?? null,
+      position_summary: extracted.positionSummary ?? null,
+      compensation: extracted.compensation ?? null,
+      benefits: extracted.benefits ?? null,
+      flags: extracted.flags ?? null,
+      claude_cost_usd: accumulatedCost,
     })
     .eq("id", id);
+
   await supabase.from("status_logs").insert({
     job_id: id,
     status: "PENDING_APPLICATION",
-    note: "Research complete",
+    note: `Research complete (cost: $${costUsd.toFixed(4)})`,
   });
 }
 
@@ -91,30 +74,11 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     return NextResponse.json({ error: "Job not found" }, { status: 404 });
   }
 
-  // If we already have the full description, re-run extraction without re-scraping
+  // If we already have the full description, re-run extraction without re-fetching
   if (job.description_full) {
     (async () => {
       try {
-        const { data: extracted, sessionId } = await parseJob((job.description_full as string).slice(0, 15000));
-
-        // Preserve existing company_id or match/create by extracted name
-        const companyId = job.company_id ?? await matchOrCreateCompanyByName(extracted.company);
-
-        await supabase
-          .from("jobs")
-          .update({
-            company_id: companyId,
-            title: extracted.title,
-            description: extracted.description,
-            session_id: sessionId,
-            status: "PENDING_APPLICATION",
-          })
-          .eq("id", id);
-        await supabase.from("status_logs").insert({
-          job_id: id,
-          status: "PENDING_APPLICATION",
-          note: "Research complete",
-        });
+        await runExtraction(id, { html: job.description_full as string });
       } catch (err) {
         console.error("Extraction failed for job", id, err);
         await supabase.from("jobs").update({ status: "RESEARCH_ERROR" }).eq("id", id);
@@ -136,7 +100,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       manualHtml = body.html;
     }
   } catch {
-    // No body / not JSON — proceed with scrape
+    // No body / not JSON — proceed with URL-based extraction
   }
 
   // Reset to RESEARCHING so the UI knows work is in progress
@@ -147,25 +111,10 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     note: manualHtml ? "Retrying with manual HTML" : "Retrying scrape",
   });
 
-  // Kick off async without blocking the response
   (async () => {
     try {
-      let html: string;
-
-      if (manualHtml) {
-        html = manualHtml;
-      } else {
-        const browser = await chromium.launch({ headless: true });
-        try {
-          const page = await browser.newPage();
-          await page.goto(job.url, { waitUntil: "networkidle", timeout: 30000 });
-          html = await page.content();
-        } finally {
-          await browser.close();
-        }
-      }
-
-      await extractAndUpdate(id, html);
+      const input = manualHtml ? { html: manualHtml } : { url: job.url as string };
+      await runExtraction(id, input);
     } catch (err) {
       console.error("Scrape failed for job", id, err);
       await supabase.from("jobs").update({ status: "RESEARCH_ERROR" }).eq("id", id);

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -13,6 +13,7 @@ import { StatusLog } from "@/components/job-detail/StatusLog";
 import { NotesSection } from "@/components/job-detail/NotesSection";
 import { QuestionsSection } from "@/components/job-detail/QuestionsSection";
 import { DuplicateJobs } from "@/components/job-detail/DuplicateJobs";
+import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, ExternalLink, Loader2, Building2, MapPin, Trash2, AlertTriangle, RefreshCw, Copy } from "lucide-react";
 import { PrivacyToggle } from "@/components/ui/privacy-toggle";
 import { PrivacyBlur } from "@/components/ui/privacy-blur";
@@ -52,6 +53,12 @@ interface Note {
   createdAt: string;
 }
 
+interface Flags {
+  green: string[];
+  yellow: string[];
+  red: string[];
+}
+
 interface Job {
   id: string;
   url: string;
@@ -67,7 +74,20 @@ interface Job {
   statusLogs: StatusLogEntry[];
   questions: Question[];
   notes: Note[];
-  duplicates?: string[]; // IDs of duplicate jobs with the same URL
+  duplicates?: string[];
+  companyWebsite: string | null;
+  companySummary: string | null;
+  workStyle: string | null;
+  requiredSkills: string[] | null;
+  preferredSkills: string[] | null;
+  primaryLanguages: string[] | null;
+  frameworks: string[] | null;
+  roleClassification: string | null;
+  positionSummary: string | null;
+  compensation: Record<string, unknown> | null;
+  benefits: string[] | null;
+  flags: Flags | null;
+  claudeCostUsd: number;
 }
 
 export default function JobDetailPage() {
@@ -215,8 +235,20 @@ export default function JobDetailPage() {
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center justify-between flex-wrap gap-3">
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-3 flex-wrap">
                 <StatusBadge status={job.status} />
+                {job.workStyle && (
+                  <Badge variant="outline" className={
+                    job.workStyle === "remote" ? "border-green-500 text-green-700 dark:text-green-400" :
+                    job.workStyle === "hybrid" ? "border-amber-500 text-amber-700 dark:text-amber-400" :
+                    "border-blue-500 text-blue-700 dark:text-blue-400"
+                  }>
+                    {job.workStyle}
+                  </Badge>
+                )}
+                {job.roleClassification && (
+                  <Badge variant="secondary" className="text-xs">{job.roleClassification}</Badge>
+                )}
                 {job.dateApplied && (
                   <span className="text-sm text-muted-foreground flex items-center gap-1">
                     <MapPin className="h-3 w-3" />
@@ -226,6 +258,11 @@ export default function JobDetailPage() {
                 {job.resume && (
                   <span className="text-xs text-muted-foreground/70">
                     Resume: {job.resume.filename}
+                  </span>
+                )}
+                {job.claudeCostUsd > 0 && (
+                  <span className="text-xs text-muted-foreground/60" title="Accumulated Claude API cost">
+                    AI cost: ${job.claudeCostUsd.toFixed(4)}
                   </span>
                 )}
                 {job.sessionId && (
@@ -316,6 +353,139 @@ export default function JobDetailPage() {
 
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-6">
           <div className="space-y-6">
+            {/* Position Summary */}
+            {job.positionSummary && (
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-semibold text-foreground">Position Summary</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">{job.positionSummary}</p>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Skills */}
+            {(job.requiredSkills?.length || job.preferredSkills?.length || job.primaryLanguages?.length || job.frameworks?.length) ? (
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-semibold text-foreground">Skills</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {!!job.requiredSkills?.length && (
+                    <div>
+                      <p className="text-xs font-medium text-muted-foreground mb-1.5">Required</p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {job.requiredSkills.map((s) => <Badge key={s} variant="secondary">{s}</Badge>)}
+                      </div>
+                    </div>
+                  )}
+                  {!!job.preferredSkills?.length && (
+                    <div>
+                      <p className="text-xs font-medium text-muted-foreground mb-1.5">Preferred</p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {job.preferredSkills.map((s) => <Badge key={s} variant="outline">{s}</Badge>)}
+                      </div>
+                    </div>
+                  )}
+                  {!!job.primaryLanguages?.length && (
+                    <div>
+                      <p className="text-xs font-medium text-muted-foreground mb-1.5">Languages</p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {job.primaryLanguages.map((s) => <Badge key={s}>{s}</Badge>)}
+                      </div>
+                    </div>
+                  )}
+                  {!!job.frameworks?.length && (
+                    <div>
+                      <p className="text-xs font-medium text-muted-foreground mb-1.5">Frameworks</p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {job.frameworks.map((s) => <Badge key={s} variant="outline">{s}</Badge>)}
+                      </div>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            ) : null}
+
+            {/* Compensation & Benefits */}
+            {(job.compensation && Object.keys(job.compensation).length > 0) || job.benefits?.length ? (
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-semibold text-foreground">Compensation & Benefits</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {job.compensation && Object.keys(job.compensation).length > 0 && (
+                    <div className="text-sm space-y-1">
+                      {Object.entries(job.compensation).map(([k, v]) => (
+                        <div key={k} className="flex gap-2">
+                          <span className="text-muted-foreground capitalize min-w-20">{k}:</span>
+                          <span className="text-foreground">{String(v)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {!!job.benefits?.length && (
+                    <ul className="space-y-1">
+                      {job.benefits.map((b) => (
+                        <li key={b} className="text-sm text-muted-foreground flex items-start gap-2">
+                          <span className="text-green-500 shrink-0 mt-0.5">✓</span>
+                          {b}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </CardContent>
+              </Card>
+            ) : null}
+
+            {/* Flags */}
+            {(job.flags?.green?.length || job.flags?.yellow?.length || job.flags?.red?.length) ? (
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-semibold text-foreground">Highlights & Red Flags</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {!!job.flags!.green?.length && (
+                    <div>
+                      <p className="text-xs font-medium text-green-600 dark:text-green-400 mb-1.5">Green Flags</p>
+                      <ul className="space-y-1">
+                        {job.flags!.green.map((f) => (
+                          <li key={f} className="text-sm text-muted-foreground flex items-start gap-2">
+                            <span className="text-green-500 shrink-0 mt-0.5">✓</span>{f}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {!!job.flags!.yellow?.length && (
+                    <div>
+                      <p className="text-xs font-medium text-amber-600 dark:text-amber-400 mb-1.5">Yellow Flags</p>
+                      <ul className="space-y-1">
+                        {job.flags!.yellow.map((f) => (
+                          <li key={f} className="text-sm text-muted-foreground flex items-start gap-2">
+                            <span className="text-amber-500 shrink-0 mt-0.5">⚠</span>{f}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {!!job.flags!.red?.length && (
+                    <div>
+                      <p className="text-xs font-medium text-red-600 dark:text-red-400 mb-1.5">Red Flags</p>
+                      <ul className="space-y-1">
+                        {job.flags!.red.map((f) => (
+                          <li key={f} className="text-sm text-muted-foreground flex items-start gap-2">
+                            <span className="text-red-500 shrink-0 mt-0.5">✗</span>{f}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            ) : null}
+
             {/* Job Description */}
             {job.description && (
               <Card>
@@ -379,8 +549,34 @@ export default function JobDetailPage() {
             </Card>
           </div>
 
-          {/* Status History */}
-          <aside>
+          {/* Sidebar */}
+          <aside className="space-y-6">
+            {/* Company */}
+            {(job.companyWebsite || job.companySummary) && (
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-sm font-semibold text-foreground">Company</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {job.companyWebsite && (
+                    <a
+                      href={job.companyWebsite}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-primary flex items-center gap-1 hover:underline truncate"
+                    >
+                      <ExternalLink className="h-3 w-3 shrink-0" />
+                      {job.companyWebsite}
+                    </a>
+                  )}
+                  {job.companySummary && (
+                    <p className="text-sm text-muted-foreground leading-relaxed">{job.companySummary}</p>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Status History */}
             <Card>
               <CardHeader className="pb-3">
                 <CardTitle className="text-sm font-semibold text-foreground">Status History</CardTitle>

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -1,20 +1,141 @@
 import { z } from "zod";
+import { chromium } from "playwright";
 import { JobExtractionSchema } from "@/lib/schemas";
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import Anthropic from "@anthropic-ai/sdk";
 
 const jobExtractionJsonSchema = z.toJSONSchema(JobExtractionSchema, { target: "draft-07" });
 
-export async function parseJob(jobDescription: string): Promise<{ data: z.infer<typeof JobExtractionSchema>; sessionId: string | null }> {
+const fetchRenderedPage = tool(
+  "FetchRenderedPage",
+  "Fetches a JS-rendered page using a real browser and returns the full HTML content after JavaScript has executed.",
+  {
+    url: z.string().describe("The URL to fetch"),
+    waitForSelector: z
+      .string()
+      .optional()
+      .describe("CSS selector to wait for before capturing HTML"),
+    timeoutMs: z
+      .number()
+      .optional()
+      .default(15000)
+      .describe("Max wait time in ms"),
+  },
+  async ({ url, waitForSelector, timeoutMs }) => {
+    const browser = await chromium.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      await page.route("**/*.{png,jpg,jpeg,gif,webp,svg,woff,woff2,ttf}", (route) =>
+        route.abort()
+      );
+      await page.goto(url, { waitUntil: "networkidle", timeout: timeoutMs });
+      if (waitForSelector) {
+        await page.waitForSelector(waitForSelector, { timeout: timeoutMs });
+      }
+      const html = await page.content();
+      const text = await page.evaluate(() => document.body.innerText);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ html, text, url: page.url() }),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              error: error instanceof Error ? error.message : String(error),
+              url,
+            }),
+          },
+        ],
+        isError: true,
+      };
+    } finally {
+      await browser.close();
+    }
+  },
+  {
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
+  }
+);
+
+function makePlaywrightServer() {
+  return createSdkMcpServer({
+    name: "playwright-fetcher",
+    version: "1.0.0",
+    tools: [fetchRenderedPage],
+  });
+}
+
+const EXTRACTION_FIELDS = `
+- company: string
+- companyWebsite: string
+- companySummary: string (from the company's main website)
+- title: string (exact job title)
+- description: string (one sentence summary of the role)
+- workStyle: "remote" | "hybrid" | "on-site"
+- requiredSkills: string[]
+- preferredSkills: string[]
+- primaryLanguages: string[]
+- frameworks: string[]
+- roleClassification: "Frontend Only" | "Frontend-Leaning Fullstack" | "True Fullstack" | "Backend-Leaning Fullstack" | "Backend Only"
+- positionSummary: string (2-3 paragraphs)
+- compensation: object
+- benefits: string[]
+- flags: { green: string[], yellow: string[], red: string[] }
+- fullJobPostingHtml: string`.trim();
+
+export async function parseJob(
+  input: { url: string } | { html: string }
+): Promise<{ data: z.infer<typeof JobExtractionSchema>; sessionId: string | null; costUsd: number }> {
+  const isUrl = "url" in input;
+
+  const prompt = isUrl
+    ? `Research this job posting URL and return a single JSON object with these fields:
+${EXTRACTION_FIELDS}
+
+Strategy:
+1. Use FetchRenderedPage to load the job posting — it runs a real browser so JS-rendered content will be fully hydrated
+2. Use FetchRenderedPage on the company's main website for the company summary
+3. Use WebSearch + WebFetch for funding, team size, and recent news
+4. Synthesize into the JSON object above
+5. Return ONLY the JSON, no markdown fences or preamble
+
+Job posting URL: ${input.url}`
+    : `Analyze this cached job posting HTML and return a single JSON object with these fields:
+${EXTRACTION_FIELDS}
+
+Instructions:
+- Extract all available fields from the HTML below
+- Use WebSearch + WebFetch for company summary, funding, and team size
+- Return ONLY the JSON, no markdown fences or preamble
+
+Job posting HTML:
+${input.html.slice(0, 30000)}`;
+
   let structuredOutput: unknown;
   let sessionId: string | null = null;
+  let costUsd = 0;
+
   for await (const message of query({
-    prompt: `Extract the company name, job title, and a concise job description from the following job posting content. Return only what is asked — do not add commentary.\n\n${jobDescription}`,
+    prompt,
     options: {
-      maxTurns: 3,
+      maxTurns: 12,
       outputFormat: {
         type: "json_schema",
         schema: jobExtractionJsonSchema,
       },
+      allowedTools: ["WebFetch", "WebSearch"],
+      ...(isUrl ? { mcpServers: { playwright: makePlaywrightServer() } } : {}),
+      permissionMode: "acceptEdits",
     },
   })) {
     if (message.type === "system" && message.subtype === "api_retry") {
@@ -23,6 +144,7 @@ export async function parseJob(jobDescription: string): Promise<{ data: z.infer<
     if (message.type === "result" && message.subtype === "success") {
       structuredOutput = message.structured_output;
       sessionId = message.session_id;
+      costUsd = message.total_cost_usd ?? 0;
     } else if (message.type === "result") {
       throw new Error(`Agent extraction failed: ${message.subtype}`);
     }
@@ -32,7 +154,7 @@ export async function parseJob(jobDescription: string): Promise<{ data: z.infer<
     throw new Error("No structured output returned from extraction");
   }
 
-  return { data: JobExtractionSchema.parse(structuredOutput), sessionId };
+  return { data: JobExtractionSchema.parse(structuredOutput), sessionId, costUsd };
 }
 
 export async function* generateWithSession(
@@ -58,9 +180,6 @@ export async function* generateWithSession(
     }
   }
 }
-
-
-import Anthropic from "@anthropic-ai/sdk";
 
 export const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -18,8 +18,31 @@ export type JobStatus = z.infer<typeof JobStatusEnum>;
 
 export const JobExtractionSchema = z.object({
   company: z.string(),
+  companyWebsite: z.string().optional(),
+  companySummary: z.string().optional(),
   title: z.string(),
   description: z.string(),
+  workStyle: z.enum(["remote", "hybrid", "on-site"]).optional(),
+  requiredSkills: z.array(z.string()).optional(),
+  preferredSkills: z.array(z.string()).optional(),
+  primaryLanguages: z.array(z.string()).optional(),
+  frameworks: z.array(z.string()).optional(),
+  roleClassification: z.enum([
+    "Frontend Only",
+    "Frontend-Leaning Fullstack",
+    "True Fullstack",
+    "Backend-Leaning Fullstack",
+    "Backend Only",
+  ]).optional(),
+  positionSummary: z.string().optional(),
+  compensation: z.record(z.unknown()).optional(),
+  benefits: z.array(z.string()).optional(),
+  flags: z.object({
+    green: z.array(z.string()),
+    yellow: z.array(z.string()),
+    red: z.array(z.string()),
+  }).optional(),
+  fullJobPostingHtml: z.string().optional(),
 });
 export type JobExtraction = z.infer<typeof JobExtractionSchema>;
 

--- a/supabase/migrations/004_enrich_jobs.sql
+++ b/supabase/migrations/004_enrich_jobs.sql
@@ -1,0 +1,14 @@
+ALTER TABLE jobs
+  ADD COLUMN IF NOT EXISTS company_website     text,
+  ADD COLUMN IF NOT EXISTS company_summary     text,
+  ADD COLUMN IF NOT EXISTS work_style          text,
+  ADD COLUMN IF NOT EXISTS required_skills     text[],
+  ADD COLUMN IF NOT EXISTS preferred_skills    text[],
+  ADD COLUMN IF NOT EXISTS primary_languages   text[],
+  ADD COLUMN IF NOT EXISTS frameworks          text[],
+  ADD COLUMN IF NOT EXISTS role_classification text,
+  ADD COLUMN IF NOT EXISTS position_summary    text,
+  ADD COLUMN IF NOT EXISTS compensation        jsonb,
+  ADD COLUMN IF NOT EXISTS benefits            text[],
+  ADD COLUMN IF NOT EXISTS flags               jsonb,
+  ADD COLUMN IF NOT EXISTS claude_cost_usd     numeric NOT NULL DEFAULT 0;


### PR DESCRIPTION
- parseJob now accepts a URL or cached HTML; when given a URL it wires up a
  Playwright-backed in-process MCP server (FetchRenderedPage) so Claude fetches
  and hydrates JS-rendered pages itself, then researches the company via
  WebSearch/WebFetch — no more manual Playwright + decant pipeline in the route
- JobExtractionSchema expanded with: companyWebsite, companySummary, workStyle,
  requiredSkills, preferredSkills, primaryLanguages, frameworks,
  roleClassification, positionSummary, compensation, benefits, flags,
  fullJobPostingHtml
- parseJob returns costUsd (from message.total_cost_usd) alongside data/sessionId
- scrape/route.ts accumulates cost into claude_cost_usd (running total per job)
  and persists all enriched fields; cached fullJobPostingHtml is reused on
  re-runs to avoid paying for another Playwright fetch
- Migration 004_enrich_jobs.sql adds all new columns + claude_cost_usd numeric

https://claude.ai/code/session_01RBXDxbsyN9GDi7dTysRniE