### PR TITLE
Add EXPIRED job status and migrate expired WITHDRAWN jobs

### DIFF
--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+export async function GET() {
+  const { data: jobs, error } = await supabase
+    .from("jobs")
+    .select(`
+      id, url, title, created_at, updated_at,
+      companies(name),
+      status_logs(status, note, created_at),
+      notes(content, created_at)
+    `)
+    .eq("status", "EXPIRED")
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const shaped = (jobs ?? []).map((job) => {
+    const companyJoin = job.companies as { name: string } | null;
+    const sortedLogs = [...(job.status_logs ?? [])].sort(
+      (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    );
+    const sortedNotes = [...(job.notes ?? [])].sort(
+      (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    );
+    return {
+      id: job.id,
+      url: job.url,
+      title: job.title,
+      company: companyJoin?.name ?? null,
+      createdAt: job.created_at,
+      updatedAt: job.updated_at,
+      statusLogs: sortedLogs.map((l) => ({
+        status: l.status,
+        note: l.note,
+        createdAt: l.created_at,
+      })),
+      notes: sortedNotes.map((n) => ({
+        content: n.content,
+        createdAt: n.created_at,
+      })),
+    };
+  });
+
+  return NextResponse.json({ jobs: shaped });
+}

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -7,6 +7,7 @@ export async function GET(req: NextRequest) {
   const showDeleted = req.nextUrl.searchParams.get("showDeleted") === "true";
   const showDenied = req.nextUrl.searchParams.get("showDenied") === "true";
   const showWithdrawn = req.nextUrl.searchParams.get("showWithdrawn") === "true";
+  const showExpired = req.nextUrl.searchParams.get("showExpired") === "true";
 
   let query = supabase
     .from("jobs")
@@ -21,6 +22,9 @@ export async function GET(req: NextRequest) {
   }
   if (!showWithdrawn) {
     query = query.neq("status", "WITHDRAWN");
+  }
+  if (!showExpired) {
+    query = query.neq("status", "EXPIRED");
   }
 
   const { data: jobs } = await query;

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -10,6 +10,7 @@ const APPLIED_STATUSES = new Set([
   "OFFERED",
   "DENIED",
   "WITHDRAWN",
+  "EXPIRED",
 ]);
 
 const ALL_STATUSES = [
@@ -21,6 +22,7 @@ const ALL_STATUSES = [
   "OFFERED",
   "DENIED",
   "WITHDRAWN",
+  "EXPIRED",
 ] as const;
 
 type JobStatus = (typeof ALL_STATUSES)[number];

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -30,6 +30,7 @@ const ALL_STATUSES: { value: JobStatus; label: string }[] = [
   { value: "OFFERED", label: "Offered" },
   { value: "DENIED", label: "Denied" },
   { value: "WITHDRAWN", label: "Withdrawn" },
+  { value: "EXPIRED", label: "Expired" },
 ];
 
 interface StatusLogEntry {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,7 @@ const STATUS_PRIORITY: Record<JobStatus, number> = {
   APPLIED: 1,
   DENIED: 0,
   WITHDRAWN: 0,
+  EXPIRED: 0,
 };
 
 function sortJobs(list: Job[]): Job[] {
@@ -73,6 +74,7 @@ export default function HomePage() {
   const [showDeleted, setShowDeleted] = useState(false);
   const [showDenied, setShowDenied] = useState(false);
   const [showWithdrawn, setShowWithdrawn] = useState(false);
+  const [showExpired, setShowExpired] = useState(false);
   const [companySearch, setCompanySearch] = useState("");
   const [showArchived, setShowArchived] = useState(false);
 
@@ -89,6 +91,7 @@ export default function HomePage() {
     if (showDeleted) params.set("showDeleted", "true");
     if (showDenied) params.set("showDenied", "true");
     if (showWithdrawn) params.set("showWithdrawn", "true");
+    if (showExpired) params.set("showExpired", "true");
     const url = `/api/jobs${params.size ? `?${params}` : ""}`;
     fetch(url)
       .then((r) => r.json())
@@ -99,7 +102,7 @@ export default function HomePage() {
   useEffect(() => {
     refreshJobs();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showDeleted, showDenied, showWithdrawn]);
+  }, [showDeleted, showDenied, showWithdrawn, showExpired]);
 
   // Poll researching jobs every 3s
   useEffect(() => {
@@ -221,9 +224,9 @@ export default function HomePage() {
                   className="w-40 h-7 text-sm"
                 />
                 <div className="flex items-center gap-4 shrink-0">
-                  {(["denied", "withdrawn", "deleted"] as const).map((key) => {
-                    const checked = key === "denied" ? showDenied : key === "withdrawn" ? showWithdrawn : showDeleted;
-                    const setter = key === "denied" ? setShowDenied : key === "withdrawn" ? setShowWithdrawn : setShowDeleted;
+                  {(["denied", "withdrawn", "expired", "deleted"] as const).map((key) => {
+                    const checked = key === "denied" ? showDenied : key === "withdrawn" ? showWithdrawn : key === "expired" ? showExpired : showDeleted;
+                    const setter = key === "denied" ? setShowDenied : key === "withdrawn" ? setShowWithdrawn : key === "expired" ? setShowExpired : setShowDeleted;
                     return (
                       <label key={key} className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer select-none">
                         <input

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import { AddJobDialog } from "@/components/jobs/AddJobDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { Plus, Briefcase, ChevronRight, Inbox, Loader2, MoreHorizontal, Upload, Eye, EyeOff, X } from "lucide-react";
+import { Plus, Briefcase, ChevronRight, Inbox, Loader2, MoreHorizontal, Upload, Eye, EyeOff, X, SlidersHorizontal, Check } from "lucide-react";
 import type { JobStatus } from "@/lib/schemas";
 import { usePrivacy } from "@/lib/privacy-context";
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu";
@@ -284,22 +284,39 @@ export default function HomePage() {
                   </Button>
                 )}
                 </div>
-                <div className="flex items-center gap-4 shrink-0">
-                  {(["denied", "withdrawn", "expired", "deleted"] as const).map((key) => {
-                    const checked = key === "denied" ? showDenied : key === "withdrawn" ? showWithdrawn : key === "expired" ? showExpired : showDeleted;
-                    const setter = key === "denied" ? setShowDenied : key === "withdrawn" ? setShowWithdrawn : key === "expired" ? setShowExpired : setShowDeleted;
-                    return (
-                      <label key={key} className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer select-none">
-                        <input
-                          type="checkbox"
-                          checked={checked}
-                          onChange={(e) => setter(e.target.checked)}
-                          className="accent-foreground"
-                        />
-                        Show {key}
-                      </label>
-                    );
-                  })}
+                <div className="flex items-center gap-2 shrink-0">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline" size="sm" className="h-7 gap-1.5 text-sm">
+                        <SlidersHorizontal className="h-3.5 w-3.5" />
+                        Filters
+                        {[showDenied, showWithdrawn, showExpired, showDeleted].filter(Boolean).length > 0 && (
+                          <Badge variant="secondary" className="ml-0.5 px-1 py-0 text-xs leading-none">
+                            {[showDenied, showWithdrawn, showExpired, showDeleted].filter(Boolean).length}
+                          </Badge>
+                        )}
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {([
+                        ["Denied", showDenied, setShowDenied],
+                        ["Withdrawn", showWithdrawn, setShowWithdrawn],
+                        ["Expired", showExpired, setShowExpired],
+                        ["Deleted", showDeleted, setShowDeleted],
+                      ] as [string, boolean, (v: boolean) => void][]).map(([label, active, setter]) => (
+                        <DropdownMenuItem
+                          key={label}
+                          onSelect={(e) => { e.preventDefault(); setter(!active); }}
+                          className="gap-2"
+                        >
+                          <span className="flex h-4 w-4 items-center justify-center">
+                            {active && <Check className="h-3.5 w-3.5" />}
+                          </span>
+                          Show {label}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
               </div>
 

--- a/src/components/jobs/CsvImportButton.tsx
+++ b/src/components/jobs/CsvImportButton.tsx
@@ -61,7 +61,8 @@ function parseCSV(text: string): string[][] {
 const STATUS_MAP: Record<string, JobStatus> = {
   applied: "APPLIED",
   denied: "DENIED",
-  "expired post": "WITHDRAWN",
+  expired: "EXPIRED",
+  "expired post": "EXPIRED",
   withdrawn: "WITHDRAWN",
   interviewing: "INTERVIEWING",
   "waiting on interview feedback": "INTERVIEWING",

--- a/src/components/jobs/JobCard.tsx
+++ b/src/components/jobs/JobCard.tsx
@@ -17,6 +17,7 @@ const ALL_STATUSES: { value: JobStatus; label: string }[] = [
   { value: "OFFERED", label: "Offered" },
   { value: "DENIED", label: "Denied" },
   { value: "WITHDRAWN", label: "Withdrawn" },
+  { value: "EXPIRED", label: "Expired" },
 ];
 
 interface Job {

--- a/src/components/jobs/StatusBadge.tsx
+++ b/src/components/jobs/StatusBadge.tsx
@@ -11,6 +11,7 @@ const STATUS_CONFIG: Record<JobStatus, { label: string; className: string }> = {
   OFFERED: { label: "Offered", className: "bg-green-100 text-green-700 border-green-200 dark:bg-green-950/50 dark:text-green-300 dark:border-green-900" },
   DENIED: { label: "Denied", className: "bg-red-100 text-red-700 border-red-200 dark:bg-red-950/50 dark:text-red-300 dark:border-red-900" },
   WITHDRAWN: { label: "Withdrawn", className: "bg-muted text-muted-foreground border-border" },
+  EXPIRED: { label: "Expired", className: "bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-950/50 dark:text-orange-300 dark:border-orange-900" },
 };
 
 export function StatusBadge({ status }: { status: JobStatus }) {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -11,6 +11,7 @@ export const JobStatusEnum = z.enum([
   "OFFERED",
   "DENIED",
   "WITHDRAWN",
+  "EXPIRED",
 ]);
 export type JobStatus = z.infer<typeof JobStatusEnum>;
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -247,6 +247,7 @@ export type Database = {
         | "DENIED"
         | "WITHDRAWN"
         | "RESEARCH_ERROR"
+        | "EXPIRED"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/supabase/migrations/006_add_expired_status.sql
+++ b/supabase/migrations/006_add_expired_status.sql
@@ -1,0 +1,26 @@
+-- Add EXPIRED to the job_status enum
+ALTER TYPE job_status ADD VALUE IF NOT EXISTS 'EXPIRED';
+
+-- Migrate WITHDRAWN jobs where a status_log note mentions "expired"
+UPDATE jobs
+SET status = 'EXPIRED', updated_at = now()
+WHERE status = 'WITHDRAWN'
+  AND id IN (
+    SELECT DISTINCT job_id FROM status_logs
+    WHERE lower(note) LIKE '%expired%'
+  );
+
+-- Also migrate WITHDRAWN jobs where a free-form note mentions "expired"
+UPDATE jobs
+SET status = 'EXPIRED', updated_at = now()
+WHERE status = 'WITHDRAWN'
+  AND id IN (
+    SELECT DISTINCT job_id FROM notes
+    WHERE lower(content) LIKE '%expired%'
+  );
+
+-- Insert a status_log entry for every migrated job (audit trail)
+INSERT INTO status_logs (job_id, status, note)
+SELECT id, 'EXPIRED', 'Migrated from WITHDRAWN: job posting expired'
+FROM jobs
+WHERE status = 'EXPIRED';


### PR DESCRIPTION
Adds a dedicated EXPIRED status to distinguish job postings that timed
out from voluntary withdrawals. Includes a DB migration that moves any
WITHDRAWN job with "expired" in its notes/status-log to EXPIRED and
writes an audit status_log entry for each migrated row. Adds a GET
/api/audit endpoint returning all EXPIRED jobs with their full
status-log and notes history for post-migration verification.

https://claude.ai/code/session_018566rMow7nRT3JynzRmLKr