### PR TITLE
Support multiple resumes with default selection and performance tracking

### DIFF
--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -100,16 +100,19 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       description: body.description,
       description_full: body.descriptionFull,
       date_applied: body.dateApplied ? new Date(body.dateApplied).toISOString() : undefined,
+      ...(body.resumeId !== undefined ? { resume_id: body.resumeId } : {}),
     })
     .eq("id", id)
-    .select("*, companies(name)")
+    .select("*, companies(name), resume:resumes(id, filename)")
     .single();
 
   if (error || !job) {
     return NextResponse.json({ error: error?.message ?? "Update failed" }, { status: 500 });
   }
 
-  const companyJoin = (job as unknown as Record<string, unknown>).companies as { name: string } | null;
+  const jobData = job as unknown as Record<string, unknown>;
+  const companyJoin = jobData.companies as { name: string } | null;
+  const resumeJoin = jobData.resume as { id: string; filename: string } | null;
 
   return NextResponse.json({
     id: job.id,
@@ -121,6 +124,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     status: job.status,
     dateApplied: job.date_applied,
     resumeId: job.resume_id,
+    resume: resumeJoin ?? null,
     createdAt: job.created_at,
     updatedAt: job.updated_at,
   });

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -67,11 +67,11 @@ export async function POST(req: NextRequest) {
 
   const { url, company, title } = parsed.data;
 
-  // Get the currently active resume
+  // Get the default resume
   const { data: resume } = await supabase
     .from("resumes")
     .select("id")
-    .order("created_at", { ascending: false })
+    .eq("is_default", true)
     .limit(1)
     .single();
 

--- a/src/app/api/resume/[id]/default/route.ts
+++ b/src/app/api/resume/[id]/default/route.ts
@@ -1,0 +1,18 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  // Clear existing default, then set the new one
+  await supabase.from("resumes").update({ is_default: false }).eq("is_default", true);
+  const { error } = await supabase.from("resumes").update({ is_default: true }).eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/resume/parse/route.ts
+++ b/src/app/api/resume/parse/route.ts
@@ -1,6 +1,7 @@
 export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
+import { anthropic } from "@/lib/claude";
 // pdf-parse is CJS-only; use require to avoid ESM default-export issues
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const pdfParse = require("pdf-parse-new") as (buf: Buffer) => Promise<{ text: string }>;
@@ -16,13 +17,32 @@ export async function POST(req: NextRequest) {
   const bytes = await file.arrayBuffer();
   const buffer = Buffer.from(bytes);
 
-  let content: string;
+  let rawText: string;
 
   if (file.type === "application/pdf" || file.name.endsWith(".pdf")) {
     const parsed = await pdfParse(buffer);
-    content = parsed.text;
+    rawText = parsed.text;
   } else {
-    content = buffer.toString("utf-8");
+    rawText = buffer.toString("utf-8");
+  }
+
+  // Use Claude to convert raw extracted text into clean, structured markdown
+  let content = rawText;
+  try {
+    const response = await anthropic.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 4096,
+      system:
+        "Convert the following raw resume text into clean, well-structured markdown. Preserve all content faithfully. Use headers for sections (e.g. # Full Name, ## Summary, ## Experience, ## Education, ## Skills). Fix spacing and formatting issues common in PDF extraction. Output only the markdown — no commentary, no code fences.",
+      messages: [{ role: "user", content: rawText.slice(0, 20000) }],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const block = (response.content as any[]).find((b) => b.type === "text");
+    if (block?.text) {
+      content = block.text;
+    }
+  } catch {
+    // Fall back to raw text if Claude call fails
   }
 
   return NextResponse.json({ content });

--- a/src/app/api/resume/route.ts
+++ b/src/app/api/resume/route.ts
@@ -6,8 +6,8 @@ import { supabase } from "@/lib/supabase";
 export async function GET() {
   const { data: resume } = await supabase
     .from("resumes")
-    .select("id, filename, content, created_at, pdf_path")
-    .order("created_at", { ascending: false })
+    .select("id, filename, content, created_at, pdf_path, is_default")
+    .eq("is_default", true)
     .limit(1)
     .single();
 
@@ -19,6 +19,7 @@ export async function GET() {
     content: resume.content,
     createdAt: resume.created_at,
     hasPdf: resume.pdf_path !== null,
+    isDefault: resume.is_default,
   });
 }
 
@@ -56,9 +57,12 @@ export async function POST(req: NextRequest) {
     pdfPath = storagePath;
   }
 
+  // Clear existing default before inserting new resume
+  await supabase.from("resumes").update({ is_default: false }).eq("is_default", true);
+
   const { data: resume, error } = await supabase
     .from("resumes")
-    .insert({ filename: file.name, content, pdf_path: pdfPath })
+    .insert({ filename: file.name, content, pdf_path: pdfPath, is_default: true })
     .select()
     .single();
 
@@ -76,6 +80,7 @@ export async function POST(req: NextRequest) {
       content: resume.content,
       createdAt: resume.created_at,
       hasPdf: resume.pdf_path !== null,
+      isDefault: resume.is_default,
     },
     { status: 201 }
   );

--- a/src/app/api/resumes/route.ts
+++ b/src/app/api/resumes/route.ts
@@ -1,0 +1,47 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+const TERMINAL_STATUSES = new Set(["APPLIED", "INTERVIEWING", "OFFERED", "DENIED", "WITHDRAWN"]);
+const INTERVIEW_STATUSES = new Set(["INTERVIEWING", "OFFERED"]);
+
+export async function GET() {
+  const [resumesResult, jobsResult] = await Promise.all([
+    supabase
+      .from("resumes")
+      .select("id, filename, content, created_at, pdf_path, is_default")
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("jobs")
+      .select("resume_id, status")
+      .not("resume_id", "is", null)
+      .is("deleted_at", null),
+  ]);
+
+  const resumes = resumesResult.data ?? [];
+  const jobs = jobsResult.data ?? [];
+
+  const perfMap = new Map<string, { totalJobs: number; applied: number; interviews: number; offers: number }>();
+  for (const job of jobs) {
+    if (!job.resume_id) continue;
+    const p = perfMap.get(job.resume_id) ?? { totalJobs: 0, applied: 0, interviews: 0, offers: 0 };
+    p.totalJobs++;
+    if (TERMINAL_STATUSES.has(job.status)) p.applied++;
+    if (INTERVIEW_STATUSES.has(job.status)) p.interviews++;
+    if (job.status === "OFFERED") p.offers++;
+    perfMap.set(job.resume_id, p);
+  }
+
+  const result = resumes.map((r) => ({
+    id: r.id,
+    filename: r.filename,
+    content: r.content,
+    createdAt: r.created_at,
+    hasPdf: r.pdf_path !== null,
+    isDefault: r.is_default,
+    performance: perfMap.get(r.id) ?? { totalJobs: 0, applied: 0, interviews: 0, offers: 0 },
+  }));
+
+  return NextResponse.json(result);
+}

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -204,7 +204,8 @@ export default function JobDetailPage() {
           </Link>
           <div className="flex-1 min-w-0">
             <h1 className="font-semibold text-foreground truncate">
-              {job.title ?? "Unknown Position"}
+              <span style={{marginRight:'8px'}}>{job.title ?? "Unknown Position"}</span>
+                <StatusBadge status={job.status} />
             </h1>
             {job.company && (
               <p className="text-sm text-muted-foreground flex items-center gap-1">
@@ -227,15 +228,6 @@ export default function JobDetailPage() {
           <PrivacyToggle />
           <EditJobDialog job={job} onSave={(updated) => setJob((prev) => prev ? { ...prev, ...updated } : prev)} />
           <DeleteJob job={job} onDelete={() => router.push("/")} />
-          {/* <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 text-muted-foreground hover:text-destructive"
-            onClick={() => setShowDeleteConfirm(true)}
-            title="Delete job"
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button> */}
         </div>
       </header>
 
@@ -249,7 +241,6 @@ export default function JobDetailPage() {
           <CardContent className="p-4">
             <div className="flex items-center justify-between flex-wrap gap-3">
               <div className="flex items-center gap-3">
-                <StatusBadge status={job.status} />
                 {job.dateApplied && (
                   <span className="text-sm text-muted-foreground flex items-center gap-1">
                     <MapPin className="h-3 w-3" />
@@ -278,7 +269,8 @@ export default function JobDetailPage() {
                     </Select>
                   </div>
                 )}
-                {job.sessionId && (
+                    {/* TODO: resolve session ID display when we resolve sessions */}
+                {/* {job.sessionId && (
                   <div className="flex items-center gap-1.5">
                     <span className="text-xs text-muted-foreground/70">Session:</span>
                     <code
@@ -297,7 +289,7 @@ export default function JobDetailPage() {
                       <Copy className="h-3 w-3" />
                     </Button>
                   </div>
-                )}
+                )} */}
               </div>
               <div className="flex items-center gap-2">
                 {updatingStatus && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -52,6 +52,13 @@ interface Note {
   createdAt: string;
 }
 
+interface ResumeOption {
+  id: string;
+  filename: string;
+  createdAt: string;
+  isDefault: boolean;
+}
+
 interface Job {
   id: string;
   url: string;
@@ -78,10 +85,10 @@ export default function JobDetailPage() {
   const [job, setJob] = useState<Job | null>(null);
   const [loading, setLoading] = useState(true);
   const [updatingStatus, setUpdatingStatus] = useState(false);
-  // const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  // const [deleting, setDeleting] = useState(false);
   const [manualHtml, setManualHtml] = useState("");
   const [retrying, setRetrying] = useState(false);
+  const [resumeOptions, setResumeOptions] = useState<ResumeOption[]>([]);
+  const [updatingResume, setUpdatingResume] = useState(false);
 
   const fetchJob = useCallback(() => {
     setLoading(true);
@@ -94,9 +101,17 @@ export default function JobDetailPage() {
       .catch(() => router.push("/"))
       .finally(() => setLoading(false));
   }, [id, router]);
+
   useEffect(() => {
     fetchJob();
   }, [fetchJob]);
+
+  useEffect(() => {
+    fetch("/api/resumes")
+      .then((r) => r.json())
+      .then((data: ResumeOption[]) => setResumeOptions(data))
+      .catch(console.error);
+  }, []);
 
   async function handleStatusChange(status: string) {
     if (!job) return;
@@ -126,6 +141,23 @@ export default function JobDetailPage() {
   //     setDeleting(false);
   //   }
   // }
+
+  async function handleResumeChange(resumeId: string) {
+    if (!job) return;
+    setUpdatingResume(true);
+    try {
+      const res = await fetch(`/api/jobs/${job.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ resumeId }),
+      });
+      if (!res.ok) throw new Error("Failed to update resume");
+      const updated = await res.json();
+      setJob((prev) => prev ? { ...prev, resume: updated.resume } : prev);
+    } finally {
+      setUpdatingResume(false);
+    }
+  }
 
   async function handleRescrape(html?: string) {
     if (!job) return;
@@ -223,10 +255,27 @@ export default function JobDetailPage() {
                     Applied {new Date(job.dateApplied).toLocaleDateString()}
                   </span>
                 )}
-                {job.resume && (
-                  <span className="text-xs text-muted-foreground/70">
-                    Resume: {job.resume.filename}
-                  </span>
+                {resumeOptions.length > 0 && (
+                  <div className="flex items-center gap-1.5">
+                    {updatingResume && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+                    <Select
+                      value={job.resume?.id ?? "none"}
+                      onValueChange={(v) => handleResumeChange(v)}
+                      disabled={updatingResume}
+                    >
+                      <SelectTrigger className="h-6 text-xs w-44 text-muted-foreground border-0 bg-transparent px-1 shadow-none">
+                        <SelectValue placeholder="No resume" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {resumeOptions.map((r) => (
+                          <SelectItem key={r.id} value={r.id} className="text-xs">
+                            {r.filename}
+                            {r.isDefault && <span className="ml-1 text-muted-foreground">(default)</span>}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
                 )}
                 {job.sessionId && (
                   <div className="flex items-center gap-1.5">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { ResumeSection } from "@/components/resume/ResumeSection";
+import { ResumeSection, type ResumeListItem } from "@/components/resume/ResumeSection";
 import { MetricsSection } from "@/components/jobs/MetricsSection";
 import { CompaniesSection } from "@/components/companies/CompaniesSection";
 import { JobCard } from "@/components/jobs/JobCard";
@@ -14,14 +14,6 @@ import { Plus, Briefcase, ChevronRight } from "lucide-react";
 import type { JobStatus } from "@/lib/schemas";
 import { PrivacyToggle } from "@/components/ui/privacy-toggle";
 import { usePrivacy } from "@/lib/privacy-context";
-
-interface Resume {
-  id: string;
-  filename: string;
-  content: string;
-  createdAt: string;
-  hasPdf: boolean;
-}
 
 interface Job {
   id: string;
@@ -65,7 +57,7 @@ function isArchived(job: Job): boolean {
 
 export default function HomePage() {
   const { privacyMode } = usePrivacy();
-  const [resume, setResume] = useState<Resume | null>(null);
+  const [resumes, setResumes] = useState<ResumeListItem[]>([]);
   const [jobs, setJobs] = useState<Job[]>([]);
   const [loadingJobs, setLoadingJobs] = useState(true);
   const [jobUrl, setJobUrl] = useState("");
@@ -77,9 +69,9 @@ export default function HomePage() {
   const [showArchived, setShowArchived] = useState(false);
 
   useEffect(() => {
-    fetch("/api/resume")
+    fetch("/api/resumes")
       .then((r) => r.json())
-      .then(setResume)
+      .then(setResumes)
       .catch(console.error);
   }, []);
 
@@ -198,7 +190,7 @@ export default function HomePage() {
         <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6">
           <aside className="space-y-6">
             {!privacyMode && <MetricsSection />}
-            <ResumeSection resume={resume} onUpload={setResume} />
+            <ResumeSection resumes={resumes} onResumesChange={setResumes} />
           </aside>
 
           <Tabs defaultValue="applications">

--- a/src/components/resume/ResumeSection.tsx
+++ b/src/components/resume/ResumeSection.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
   DialogContent,
@@ -10,118 +11,142 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { Upload, FileText, Loader2 } from "lucide-react";
+import { Upload, FileText, Loader2, Star } from "lucide-react";
 
-interface Resume {
+export interface ResumeListItem {
   id: string;
   filename: string;
   content: string;
   createdAt: string;
   hasPdf: boolean;
+  isDefault: boolean;
+  performance: {
+    totalJobs: number;
+    applied: number;
+    interviews: number;
+    offers: number;
+  };
 }
 
 interface ResumeSectionProps {
-  resume: Resume | null;
-  onUpload: (resume: Resume) => void;
+  resumes: ResumeListItem[];
+  onResumesChange: (resumes: ResumeListItem[]) => void;
 }
 
-type Stage =
+type UploadStage =
   | { name: "idle" }
   | { name: "parsing"; file: File }
   | { name: "editing"; file: File; content: string; blobUrl: string }
   | { name: "saving" };
 
-export function ResumeSection({ resume, onUpload }: ResumeSectionProps) {
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [stage, setStage] = useState<Stage>({ name: "idle" });
-  const [error, setError] = useState("");
-  const [editedContent, setEditedContent] = useState("");
+function PerformanceSummary({ perf }: { perf: ResumeListItem["performance"] }) {
+  if (perf.totalJobs === 0) {
+    return <span className="text-muted-foreground/50">No jobs yet</span>;
+  }
+  const parts = [`${perf.totalJobs} job${perf.totalJobs !== 1 ? "s" : ""}`];
+  if (perf.applied > 0) parts.push(`${perf.applied} applied`);
+  if (perf.interviews > 0) parts.push(`${perf.interviews} interview${perf.interviews !== 1 ? "s" : ""}`);
+  if (perf.offers > 0) parts.push(`${perf.offers} offer${perf.offers !== 1 ? "s" : ""}`);
+  return <span>{parts.join(" · ")}</span>;
+}
 
-  // Clean up blob URL when editing stage is exited
+export function ResumeSection({ resumes, onResumesChange }: ResumeSectionProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadStage, setUploadStage] = useState<UploadStage>({ name: "idle" });
+  const [editedContent, setEditedContent] = useState("");
+  const [error, setError] = useState("");
+  const [previewResume, setPreviewResume] = useState<ResumeListItem | null>(null);
+  const [settingDefaultId, setSettingDefaultId] = useState<string | null>(null);
+
   useEffect(() => {
     return () => {
-      if (stage.name === "editing") {
-        URL.revokeObjectURL(stage.blobUrl);
+      if (uploadStage.name === "editing") {
+        URL.revokeObjectURL(uploadStage.blobUrl);
       }
     };
-  }, [stage]);
+  }, [uploadStage]);
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
-
     if (fileInputRef.current) fileInputRef.current.value = "";
 
     setError("");
-    setStage({ name: "parsing", file });
+    setUploadStage({ name: "parsing", file });
 
     try {
       const formData = new FormData();
       formData.append("file", file);
-
       const res = await fetch("/api/resume/parse", { method: "POST", body: formData });
       if (!res.ok) throw new Error("Parse failed");
-
       const { content } = await res.json();
       const isPdf = file.type === "application/pdf" || file.name.endsWith(".pdf");
       const blobUrl = isPdf ? URL.createObjectURL(file) : "";
-
       setEditedContent(content);
-      setStage({ name: "editing", file, content, blobUrl });
+      setUploadStage({ name: "editing", file, content, blobUrl });
     } catch {
       setError("Failed to parse file. Please try again.");
-      setStage({ name: "idle" });
+      setUploadStage({ name: "idle" });
     }
   }
 
   function handleCancel() {
-    if (stage.name === "editing") {
-      URL.revokeObjectURL(stage.blobUrl);
-    }
-    setStage({ name: "idle" });
+    if (uploadStage.name === "editing") URL.revokeObjectURL(uploadStage.blobUrl);
+    setUploadStage({ name: "idle" });
     setError("");
   }
 
   async function handleSave() {
-    if (stage.name !== "editing") return;
-
-    const { file, blobUrl } = stage;
-    setStage({ name: "saving" });
+    if (uploadStage.name !== "editing") return;
+    const { file, blobUrl } = uploadStage;
+    setUploadStage({ name: "saving" });
 
     try {
       const formData = new FormData();
       formData.append("file", file);
       formData.append("content", editedContent);
-
       const res = await fetch("/api/resume", { method: "POST", body: formData });
       if (!res.ok) throw new Error("Upload failed");
-
-      const data: Resume = await res.json();
       URL.revokeObjectURL(blobUrl);
-      onUpload(data);
-      setStage({ name: "idle" });
+      // Refresh full list from server
+      const listRes = await fetch("/api/resumes");
+      const updated: ResumeListItem[] = await listRes.json();
+      onResumesChange(updated);
+      setUploadStage({ name: "idle" });
     } catch {
       setError("Failed to save resume. Please try again.");
-      setStage({ name: "editing", file, content: editedContent, blobUrl });
+      setUploadStage({ name: "editing", file, content: editedContent, blobUrl });
     }
   }
 
-  const isParsing = stage.name === "parsing";
-  const isSaving = stage.name === "saving";
-  const isEditing = stage.name === "editing";
-  const editingFile = isEditing ? (stage as { name: "editing"; file: File; content: string; blobUrl: string }) : null;
-  const isPdf = editingFile
-    ? editingFile.file.type === "application/pdf" || editingFile.file.name.endsWith(".pdf")
+  async function handleSetDefault(resumeId: string) {
+    setSettingDefaultId(resumeId);
+    try {
+      await fetch(`/api/resume/${resumeId}/default`, { method: "POST" });
+      onResumesChange(resumes.map((r) => ({ ...r, isDefault: r.id === resumeId })));
+    } finally {
+      setSettingDefaultId(null);
+    }
+  }
+
+  const isParsing = uploadStage.name === "parsing";
+  const isSaving = uploadStage.name === "saving";
+  const isEditing = uploadStage.name === "editing";
+  const editingStage = isEditing
+    ? (uploadStage as { name: "editing"; file: File; content: string; blobUrl: string })
+    : null;
+  const isPdf = editingStage
+    ? editingStage.file.type === "application/pdf" || editingStage.file.name.endsWith(".pdf")
     : false;
 
   return (
     <>
-      <Card className="h-full">
+      <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-base flex items-center justify-between">
             <span className="flex items-center gap-2">
               <FileText className="h-4 w-4" />
-              Resume
+              Resumes
             </span>
             <Button
               variant="ghost"
@@ -131,14 +156,14 @@ export function ResumeSection({ resume, onUpload }: ResumeSectionProps) {
               className="text-xs"
             >
               {isParsing ? (
-                <><Loader2 className="h-3 w-3 animate-spin" /> Parsing...</>
+                <><Loader2 className="h-3 w-3 animate-spin mr-1" /> Parsing…</>
               ) : (
-                <><Upload className="h-3 w-3" /> {resume ? "Replace" : "Upload"}</>
+                <><Upload className="h-3 w-3 mr-1" /> Upload</>
               )}
             </Button>
           </CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-2">
           <input
             ref={fileInputRef}
             type="file"
@@ -149,71 +174,90 @@ export function ResumeSection({ resume, onUpload }: ResumeSectionProps) {
 
           {error && <p className="text-xs text-red-500 mb-2">{error}</p>}
 
-          {resume ? (
+          {resumes.length === 0 ? (
             <div
-              className="cursor-pointer group"
-              onClick={() => fileInputRef.current?.click()}
-              title="Click to replace resume"
-            >
-              <p className="text-xs text-muted-foreground mb-2 font-medium group-hover:text-foreground transition-colors">
-                {resume.filename}
-                <span className="ml-2 text-muted-foreground/50">·</span>
-                <span className="ml-2 text-muted-foreground/70">
-                  {new Date(resume.createdAt).toLocaleDateString()}
-                </span>
-              </p>
-              <div className="h-64 overflow-hidden rounded border border-border bg-muted group-hover:border-ring/50 transition-colors">
-                {resume.hasPdf ? (
-                  <iframe
-                    src={`/api/resume/${resume.id}/pdf`}
-                    className="w-full h-full"
-                    title={resume.filename}
-                    onClick={(e) => e.stopPropagation()}
-                  />
-                ) : (
-                  <p className="text-xs text-muted-foreground whitespace-pre-wrap leading-relaxed font-mono p-3">
-                    {resume.content.slice(0, 800)}
-                    {resume.content.length > 800 && (
-                      <span className="text-muted-foreground/50">…</span>
-                    )}
-                  </p>
-                )}
-              </div>
-            </div>
-          ) : (
-            <div
-              className="flex flex-col items-center justify-center h-48 border-2 border-dashed border-border rounded-lg cursor-pointer hover:border-ring/50 hover:bg-muted transition-colors"
+              className="flex flex-col items-center justify-center h-32 border-2 border-dashed border-border rounded-lg cursor-pointer hover:border-ring/50 hover:bg-muted transition-colors"
               onClick={() => fileInputRef.current?.click()}
             >
-              <Upload className="h-8 w-8 text-muted-foreground/50 mb-2" />
+              <Upload className="h-6 w-6 text-muted-foreground/50 mb-2" />
               <p className="text-sm text-muted-foreground">Upload your resume</p>
               <p className="text-xs text-muted-foreground/70 mt-1">PDF or plain text</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {resumes.map((resume) => (
+                <div
+                  key={resume.id}
+                  className="group flex flex-col gap-1 rounded-md border border-border px-3 py-2 hover:border-ring/40 transition-colors"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <button
+                      className="flex items-center gap-2 min-w-0 text-left"
+                      onClick={() => setPreviewResume(resume)}
+                      title="Preview resume"
+                    >
+                      <span className="text-xs font-medium truncate">{resume.filename}</span>
+                    </button>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      {resume.isDefault ? (
+                        <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4">
+                          Default
+                        </Badge>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-5 px-1.5 text-[10px] opacity-0 group-hover:opacity-100 transition-opacity"
+                          disabled={settingDefaultId === resume.id}
+                          onClick={() => handleSetDefault(resume.id)}
+                          title="Set as default"
+                        >
+                          {settingDefaultId === resume.id ? (
+                            <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                          ) : (
+                            <Star className="h-2.5 w-2.5" />
+                          )}
+                          Set default
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <p className="text-[10px] text-muted-foreground/60">
+                      <PerformanceSummary perf={resume.performance} />
+                    </p>
+                    <p className="text-[10px] text-muted-foreground/50">
+                      {new Date(resume.createdAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                </div>
+              ))}
             </div>
           )}
         </CardContent>
       </Card>
 
+      {/* Upload review/edit dialog */}
       <Dialog open={isEditing} onOpenChange={(open) => { if (!open) handleCancel(); }}>
         <DialogContent className="max-w-10xl h-[85vh] flex flex-col gap-0 p-0">
           <DialogHeader className="px-6 py-4 border-b border-border shrink-0">
             <DialogTitle className="text-base">
-              Review Resume — {editingFile?.file.name}
+              Review Resume — {editingStage?.file.name}
             </DialogTitle>
             <p className="text-xs text-muted-foreground mt-1">
-              Verify the extracted text below. Edit the markdown to correct any parsing errors before saving.
+              Claude has structured the extracted text as markdown. Edit to correct any errors before saving.
             </p>
           </DialogHeader>
 
           <div className="flex flex-1 min-h-0 divide-x divide-border">
-            {/* PDF preview panel */}
             <div className="w-1/2 flex flex-col min-h-0">
               <p className="text-xs font-medium text-muted-foreground px-4 py-2 border-b border-border shrink-0">
                 Original PDF
               </p>
               <div className="flex-1 min-h-0">
-                {isPdf && editingFile?.blobUrl ? (
+                {isPdf && editingStage?.blobUrl ? (
                   <iframe
-                    src={editingFile.blobUrl}
+                    src={editingStage.blobUrl}
                     className="w-full h-full"
                     title="PDF preview"
                   />
@@ -225,17 +269,16 @@ export function ResumeSection({ resume, onUpload }: ResumeSectionProps) {
               </div>
             </div>
 
-            {/* Markdown editor panel */}
             <div className="w-1/2 flex flex-col min-h-0">
               <p className="text-xs font-medium text-muted-foreground px-4 py-2 border-b border-border shrink-0">
-                Extracted text (markdown)
+                Structured markdown
               </p>
               <textarea
                 className="flex-1 min-h-0 resize-none p-4 text-xs font-mono text-foreground bg-background focus:outline-none"
                 value={editedContent}
                 onChange={(e) => setEditedContent(e.target.value)}
                 spellCheck={false}
-                placeholder="Extracted resume text will appear here…"
+                placeholder="Structured resume markdown will appear here…"
               />
             </div>
           </div>
@@ -252,6 +295,40 @@ export function ResumeSection({ resume, onUpload }: ResumeSectionProps) {
               )}
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Preview dialog */}
+      <Dialog open={!!previewResume} onOpenChange={(open) => { if (!open) setPreviewResume(null); }}>
+        <DialogContent className="max-w-4xl h-[85vh] flex flex-col gap-0 p-0">
+          <DialogHeader className="px-6 py-4 border-b border-border shrink-0">
+            <DialogTitle className="text-base flex items-center gap-2">
+              {previewResume?.filename}
+              {previewResume?.isDefault && (
+                <Badge variant="secondary" className="text-[10px]">Default</Badge>
+              )}
+            </DialogTitle>
+            {previewResume && (
+              <p className="text-xs text-muted-foreground mt-1">
+                Uploaded {new Date(previewResume.createdAt).toLocaleDateString()} ·{" "}
+                <PerformanceSummary perf={previewResume.performance} />
+              </p>
+            )}
+          </DialogHeader>
+
+          <div className="flex-1 min-h-0 overflow-auto">
+            {previewResume?.hasPdf ? (
+              <iframe
+                src={`/api/resume/${previewResume.id}/pdf`}
+                className="w-full h-full"
+                title={previewResume.filename}
+              />
+            ) : (
+              <pre className="text-xs font-mono text-foreground whitespace-pre-wrap leading-relaxed p-6">
+                {previewResume?.content}
+              </pre>
+            )}
+          </div>
         </DialogContent>
       </Dialog>
     </>

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -100,6 +100,7 @@ export const UpdateJobSchema = z.object({
   description: z.string().optional(),
   descriptionFull: z.string().optional(),
   dateApplied: z.string().datetime().optional().nullable(),
+  resumeId: z.string().uuid().optional().nullable(),
 });
 export type UpdateJobInput = z.infer<typeof UpdateJobSchema>;
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -180,6 +180,7 @@ export type Database = {
           created_at: string
           filename: string
           id: string
+          is_default: boolean
           pdf_path: string | null
         }
         Insert: {
@@ -187,6 +188,7 @@ export type Database = {
           created_at?: string
           filename: string
           id?: string
+          is_default?: boolean
           pdf_path?: string | null
         }
         Update: {
@@ -194,6 +196,7 @@ export type Database = {
           created_at?: string
           filename?: string
           id?: string
+          is_default?: boolean
           pdf_path?: string | null
         }
         Relationships: []

--- a/supabase/migrations/006_resume_improvements.sql
+++ b/supabase/migrations/006_resume_improvements.sql
@@ -1,0 +1,6 @@
+ALTER TABLE resumes ADD COLUMN is_default boolean NOT NULL DEFAULT false;
+
+-- Set the most recently uploaded resume as the initial default
+UPDATE resumes
+SET is_default = true
+WHERE id = (SELECT id FROM resumes ORDER BY created_at DESC LIMIT 1);


### PR DESCRIPTION
## Summary
This PR refactors the resume management system to support multiple resumes per user, with the ability to set a default resume and track performance metrics (jobs applied, interviews, offers) for each resume.

## Key Changes

- **Multiple Resume Support**: Changed from single resume to list-based management
  - `ResumeSection` now displays all uploaded resumes in a compact list view
  - Added new `/api/resumes` endpoint to fetch all resumes with performance data
  - Updated resume data structure to include `isDefault` flag and performance metrics

- **Default Resume Selection**: 
  - Added ability to mark a resume as default via new `/api/resume/[id]/default` POST endpoint
  - New resumes automatically become the default (previous default is cleared)
  - Default resume is used when creating new job applications
  - UI shows "Default" badge and "Set default" button for non-default resumes

- **Performance Tracking**:
  - Each resume now tracks: total jobs, applied count, interviews, and offers
  - Performance summary displayed inline in resume list
  - Calculated server-side by aggregating job statuses linked to each resume

- **Resume Selection in Job Details**:
  - Added dropdown to select/change which resume was used for a specific job
  - Displays all available resumes with default indicator
  - Updates job's `resume_id` when selection changes

- **Improved Resume Parsing**:
  - Integrated Claude API to convert raw extracted text into structured markdown
  - Falls back to raw text if Claude call fails
  - Better formatting and section organization in parsed content

- **UI/UX Improvements**:
  - Compact resume list with hover actions instead of single large preview
  - Separate preview dialog for viewing full resume content
  - Better visual hierarchy with badges and performance indicators
  - Improved upload dialog messaging and layout

- **Database Schema**:
  - Added `is_default` boolean column to resumes table
  - Migration sets most recently uploaded resume as initial default

## Implementation Details

- Resume performance metrics are calculated server-side by querying jobs with terminal statuses (APPLIED, INTERVIEWING, OFFERED, DENIED, WITHDRAWN)
- Interview count includes INTERVIEWING and OFFERED statuses
- Offer count is specifically OFFERED status
- The `/api/resumes` endpoint returns enriched data with performance stats for all resumes
- Job detail page fetches available resumes on mount and allows inline resume selection

https://claude.ai/code/session_01WipzB3rqekkwAjGmFQxZyA