### PR TITLE
feat: add server-side caching to all CRUD endpoints

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   serverExternalPackages: ["pdf-parse", "pdf-parse-new", "playwright"],
   transpilePackages: ["decant"],
+  cacheComponents: true,
 };
 
 export default nextConfig;

--- a/src/app/api/companies/[id]/check/route.ts
+++ b/src/app/api/companies/[id]/check/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { supabase } from "@/lib/supabase";
+import { CacheTag } from "@/lib/cache-tags";
 
 export async function POST(
   _req: NextRequest,
@@ -17,6 +19,8 @@ export async function POST(
   if (error || !data) {
     return NextResponse.json({ error: error?.message ?? "Update failed" }, { status: 500 });
   }
+
+  revalidateTag(CacheTag.companies);
 
   return NextResponse.json({ lastCheckedAt: data.last_checked_at });
 }

--- a/src/app/api/companies/[id]/merge/route.ts
+++ b/src/app/api/companies/[id]/merge/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { supabase } from "@/lib/supabase";
 import { MergeCompanySchema } from "@/lib/schemas";
+import { CacheTag } from "@/lib/cache-tags";
 
 export async function POST(
   req: NextRequest,
@@ -59,6 +61,10 @@ export async function POST(
   if (deleteError) {
     return NextResponse.json({ error: deleteError.message }, { status: 500 });
   }
+
+  revalidateTag(CacheTag.companies);
+  revalidateTag(CacheTag.jobsList);
+  revalidateTag(CacheTag.metrics);
 
   return NextResponse.json({ success: true, targetId });
 }

--- a/src/app/api/companies/[id]/route.ts
+++ b/src/app/api/companies/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { supabase } from "@/lib/supabase";
 import { UpdateCompanySchema } from "@/lib/schemas";
+import { CacheTag } from "@/lib/cache-tags";
 import type { Database } from "@/types/supabase";
 
 type CompanyUpdate = Database["public"]["Tables"]["companies"]["Update"];
@@ -32,6 +34,8 @@ export async function PATCH(
   if (error || !data) {
     return NextResponse.json({ error: error?.message ?? "Update failed" }, { status: 500 });
   }
+
+  revalidateTag(CacheTag.companies);
 
   return NextResponse.json({
     id: data.id,

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
+import { cacheTag, cacheLife, revalidateTag } from "next/cache";
 import { supabase } from "@/lib/supabase";
 import { CreateCompanySchema } from "@/lib/schemas";
+import { CacheTag } from "@/lib/cache-tags";
 
-export async function GET() {
+async function fetchCompaniesList() {
+  "use cache";
+  cacheTag(CacheTag.companies);
+  cacheLife({ revalidate: 60 });
+
   const [{ data, error }, { data: jobRows }] = await Promise.all([
     supabase.from("companies").select("*"),
     supabase
@@ -12,9 +18,7 @@ export async function GET() {
       .not("company_id", "is", null),
   ]);
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
+  if (error) throw new Error(error.message);
 
   // Build per-company maps from job rows
   const lastAppliedMap: Record<string, string> = {};
@@ -70,7 +74,16 @@ export async function GET() {
     return new Date(da).getTime() - new Date(db).getTime();
   });
 
-  return NextResponse.json(companies);
+  return companies;
+}
+
+export async function GET() {
+  try {
+    const companies = await fetchCompaniesList();
+    return NextResponse.json(companies);
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Query failed" }, { status: 500 });
+  }
 }
 
 export async function POST(req: NextRequest) {
@@ -95,6 +108,8 @@ export async function POST(req: NextRequest) {
   if (error || !data) {
     return NextResponse.json({ error: error?.message ?? "Insert failed" }, { status: 500 });
   }
+
+  revalidateTag(CacheTag.companies);
 
   return NextResponse.json(
     {

--- a/src/app/api/jobs/[id]/notes/route.ts
+++ b/src/app/api/jobs/[id]/notes/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { supabase } from "@/lib/supabase";
 import { CreateNoteSchema } from "@/lib/schemas";
+import { CacheTag } from "@/lib/cache-tags";
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -39,6 +41,8 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   if (error || !note) {
     return NextResponse.json({ error: error?.message ?? "Insert failed" }, { status: 500 });
   }
+
+  revalidateTag(CacheTag.jobDetail(id));
 
   return NextResponse.json(
     {

--- a/src/app/api/jobs/[id]/questions/[qid]/route.ts
+++ b/src/app/api/jobs/[id]/questions/[qid]/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { supabase } from "@/lib/supabase";
 import { UpdateQuestionSchema } from "@/lib/schemas";
+import { CacheTag } from "@/lib/cache-tags";
 
 export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string; qid: string }> }
 ) {
-  const { qid } = await params;
+  const { id, qid } = await params;
   const body = await req.json();
 
   const parsed = UpdateQuestionSchema.safeParse(body);
@@ -25,6 +27,8 @@ export async function PATCH(
     return NextResponse.json({ error: error?.message ?? "Update failed" }, { status: 500 });
   }
 
+  revalidateTag(CacheTag.jobDetail(id));
+
   return NextResponse.json({
     id: question.id,
     jobId: question.job_id,
@@ -40,7 +44,8 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string; qid: string }> }
 ) {
-  const { qid } = await params;
+  const { id, qid } = await params;
   await supabase.from("questions").delete().eq("id", qid);
+  revalidateTag(CacheTag.jobDetail(id));
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { cacheTag, cacheLife, revalidateTag } from "next/cache";
 import { supabase } from "@/lib/supabase";
 import { UpdateJobSchema } from "@/lib/schemas";
+import { CacheTag } from "@/lib/cache-tags";
 
 function mapJob(job: Record<string, unknown>) {
   const companyJoin = job.companies as { name: string } | null;
@@ -47,8 +49,11 @@ function mapJob(job: Record<string, unknown>) {
   };
 }
 
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
+async function fetchJobDetail(id: string) {
+  "use cache";
+  cacheTag(CacheTag.jobDetail(id));
+  cacheTag(CacheTag.jobsList);
+  cacheLife({ revalidate: 30 });
 
   const { data: job } = await supabase
     .from("jobs")
@@ -56,9 +61,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
     .eq("id", id)
     .single();
 
-  if (!job) {
-    return NextResponse.json({ error: "Job not found" }, { status: 404 });
-  }
+  if (!job) return null;
 
   const duplicateJobs = await supabase
     .from("jobs")
@@ -67,7 +70,6 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
     .neq("id", id)
     .is("deleted_at", null);
 
-  // Sort sub-arrays
   const result = {
     ...job,
     status_logs: [...(job.status_logs ?? [])].sort(
@@ -82,7 +84,18 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
     duplicates: duplicateJobs.data ?? [],
   };
 
-  return NextResponse.json(mapJob(result as unknown as Record<string, unknown>));
+  return mapJob(result as unknown as Record<string, unknown>);
+}
+
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const data = await fetchJobDetail(id);
+
+  if (!data) {
+    return NextResponse.json({ error: "Job not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(data);
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -109,6 +122,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   if (error || !job) {
     return NextResponse.json({ error: error?.message ?? "Update failed" }, { status: 500 });
   }
+
+  revalidateTag(CacheTag.jobDetail(id));
+  revalidateTag(CacheTag.jobsList);
+  revalidateTag(CacheTag.metrics);
 
   const jobData = job as unknown as Record<string, unknown>;
   const companyJoin = jobData.companies as { name: string } | null;
@@ -137,5 +154,10 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
     .from("jobs")
     .update({ deleted_at: new Date().toISOString() })
     .eq("id", id);
+
+  revalidateTag(CacheTag.jobDetail(id));
+  revalidateTag(CacheTag.jobsList);
+  revalidateTag(CacheTag.metrics);
+
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/jobs/[id]/scrape/route.ts
+++ b/src/app/api/jobs/[id]/scrape/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { chromium } from "playwright";
 import { clean } from "decant";
 import { supabase } from "@/lib/supabase";
 import { parseJob } from "@/lib/claude";
 import { matchOrCreateCompanyByName } from "@/lib/company-matching";
+import { CacheTag } from "@/lib/cache-tags";
 
 /**
  * Reject URLs that resolve to loopback or RFC-1918 private addresses to
@@ -67,6 +69,7 @@ async function extractAndUpdate(id: string, html: string) {
     status: "RESEARCHING",
     note: "Full description scraped",
   });
+  revalidateTag(CacheTag.jobDetail(id));
 
   // 3. Extract structured data via Claude Agent SDK
   const { data: extracted, sessionId } = await parseJob(markdown.slice(0, 15000));
@@ -90,6 +93,11 @@ async function extractAndUpdate(id: string, html: string) {
     status: "PENDING_APPLICATION",
     note: "Research complete",
   });
+
+  revalidateTag(CacheTag.jobDetail(id));
+  revalidateTag(CacheTag.jobsList);
+  revalidateTag(CacheTag.companies);
+  revalidateTag(CacheTag.metrics);
 }
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -129,6 +137,11 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
           status: "PENDING_APPLICATION",
           note: "Research complete",
         });
+
+        revalidateTag(CacheTag.jobDetail(id));
+        revalidateTag(CacheTag.jobsList);
+        revalidateTag(CacheTag.companies);
+        revalidateTag(CacheTag.metrics);
       } catch (err) {
         console.error("Extraction failed for job", id, err);
         await supabase.from("jobs").update({ status: "RESEARCH_ERROR" }).eq("id", id);
@@ -137,6 +150,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
           status: "RESEARCH_ERROR",
           note: err instanceof Error ? err.message : "Unknown error during extraction",
         });
+
+        revalidateTag(CacheTag.jobDetail(id));
+        revalidateTag(CacheTag.jobsList);
       }
     })();
     return NextResponse.json({ message: "Extraction started with existing description" });
@@ -160,6 +176,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     status: "RESEARCHING",
     note: manualHtml ? "Retrying with manual HTML" : "Retrying scrape",
   });
+
+  revalidateTag(CacheTag.jobDetail(id));
+  revalidateTag(CacheTag.jobsList);
 
   // Kick off async without blocking the response
   (async () => {
@@ -191,6 +210,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
         status: "RESEARCH_ERROR",
         note: err instanceof Error ? err.message : "Unknown error",
       });
+
+      revalidateTag(CacheTag.jobDetail(id));
+      revalidateTag(CacheTag.jobsList);
     }
   })();
 

--- a/src/app/api/jobs/[id]/status/route.ts
+++ b/src/app/api/jobs/[id]/status/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { supabase } from "@/lib/supabase";
 import { UpdateStatusSchema } from "@/lib/schemas";
+import { CacheTag } from "@/lib/cache-tags";
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -30,6 +32,11 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   await supabase
     .from("status_logs")
     .insert({ job_id: id, status, note });
+
+  revalidateTag(CacheTag.jobDetail(id));
+  revalidateTag(CacheTag.jobsList);
+  revalidateTag(CacheTag.companies);
+  revalidateTag(CacheTag.metrics);
 
   const companyJoin = (job as unknown as Record<string, unknown>).companies as { name: string } | null;
 

--- a/src/app/api/jobs/import/route.ts
+++ b/src/app/api/jobs/import/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { supabase } from "@/lib/supabase";
 import { CsvImportSchema } from "@/lib/schemas";
 import { matchOrCreateCompanyByName } from "@/lib/company-matching";
+import { CacheTag } from "@/lib/cache-tags";
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
@@ -53,6 +55,12 @@ export async function POST(req: NextRequest) {
       errors.push({ row: i + 1, message: err instanceof Error ? err.message : "Unknown error" });
       skipped++;
     }
+  }
+
+  if (imported > 0) {
+    revalidateTag(CacheTag.jobsList);
+    revalidateTag(CacheTag.companies);
+    revalidateTag(CacheTag.metrics);
   }
 
   return NextResponse.json({ imported, skipped, errors }, { status: 200 });

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,13 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
+import { cacheTag, cacheLife, revalidateTag } from "next/cache";
 import { supabase } from "@/lib/supabase";
 import { CreateJobSchema } from "@/lib/schemas";
 import { matchCompanyByUrl, matchOrCreateCompanyByName } from "@/lib/company-matching";
+import { CacheTag } from "@/lib/cache-tags";
 
-export async function GET(req: NextRequest) {
-  const showDeleted = req.nextUrl.searchParams.get("showDeleted") === "true";
-  const showDenied = req.nextUrl.searchParams.get("showDenied") === "true";
-  const showWithdrawn = req.nextUrl.searchParams.get("showWithdrawn") === "true";
-  const showExpired = req.nextUrl.searchParams.get("showExpired") === "true";
+async function fetchJobsList(
+  showDeleted: boolean,
+  showDenied: boolean,
+  showWithdrawn: boolean,
+  showExpired: boolean
+) {
+  "use cache";
+  cacheTag(CacheTag.jobsList);
+  cacheLife({ revalidate: 30 });
 
   let query = supabase
     .from("jobs")
@@ -59,6 +65,16 @@ export async function GET(req: NextRequest) {
     };
   });
 
+  return shaped;
+}
+
+export async function GET(req: NextRequest) {
+  const showDeleted = req.nextUrl.searchParams.get("showDeleted") === "true";
+  const showDenied = req.nextUrl.searchParams.get("showDenied") === "true";
+  const showWithdrawn = req.nextUrl.searchParams.get("showWithdrawn") === "true";
+  const showExpired = req.nextUrl.searchParams.get("showExpired") === "true";
+
+  const shaped = await fetchJobsList(showDeleted, showDenied, showWithdrawn, showExpired);
   return NextResponse.json(shaped);
 }
 
@@ -108,6 +124,10 @@ export async function POST(req: NextRequest) {
     .insert({ job_id: job.id, status: "RESEARCHING", note: "Job added for research" })
     .select()
     .single();
+
+  revalidateTag(CacheTag.jobsList);
+  revalidateTag(CacheTag.companies);
+  revalidateTag(CacheTag.metrics);
 
   return NextResponse.json(
     {

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
+import { cacheTag, cacheLife } from "next/cache";
 import { supabase } from "@/lib/supabase";
+import { CacheTag } from "@/lib/cache-tags";
+
 const INTERVIEWING_STATUSES = new Set(["INTERVIEWING", "OFFERED"]);
 
 const ACTION_NEEDED_STATUSES = new Set(["PENDING_APPLICATION", "RESEARCH_ERROR"]);
@@ -27,14 +30,18 @@ const ALL_STATUSES = [
 
 type JobStatus = (typeof ALL_STATUSES)[number];
 
-export async function GET() {
+async function fetchMetrics() {
+  "use cache";
+  cacheTag(CacheTag.metrics);
+  cacheLife({ revalidate: 60 });
+
   const { data: jobs } = await supabase
     .from("jobs")
     .select("status, company_id, status_logs(status, created_at)")
     .is("deleted_at", null);
 
   if (!jobs) {
-    return NextResponse.json({ totalApplied: 0, uniqueCompanies: 0, avgTimePerState: {}, totalAppliedCount: 0 });
+    return { totalApplied: 0, uniqueCompanies: 0, avgTimePerState: {}, totalAppliedCount: 0 };
   }
 
   const totalNeedAction = jobs.filter((j) => ACTION_NEEDED_STATUSES.has(j.status)).length;
@@ -42,7 +49,7 @@ export async function GET() {
   const appliedJobs = jobs.filter((j) => APPLIED_STATUSES.has(j.status));
 
   const totalApplied = appliedJobs.length;
-  
+
   const activeInterviews = appliedJobs.filter((j) => INTERVIEWING_STATUSES.has(j.status)).length;
 
   const denied = appliedJobs.filter((j) => j.status === "DENIED").length;
@@ -92,5 +99,10 @@ export async function GET() {
     }
   }
 
-  return NextResponse.json({ totalApplied, uniqueCompanies, avgTimePerState, totalAppliedCount: totalApplied, activeInterviews, denied, jobsAppliedToday, totalNeedAction });
+  return { totalApplied, uniqueCompanies, avgTimePerState, totalAppliedCount: totalApplied, activeInterviews, denied, jobsAppliedToday, totalNeedAction };
+}
+
+export async function GET() {
+  const metrics = await fetchMetrics();
+  return NextResponse.json(metrics);
 }

--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -1,0 +1,6 @@
+export const CacheTag = {
+  jobsList: "jobs-list",
+  jobDetail: (id: string) => `job-detail:${id}`,
+  companies: "companies-list",
+  metrics: "metrics",
+} as const;


### PR DESCRIPTION
Uses Next.js 16 "use cache" directive (enabled via cacheComponents: true)
with tag-based invalidation so every write immediately clears stale reads.

Cached GET endpoints (with 30–60 s safety-net revalidate):
- GET /api/jobs          → tag: jobs-list
- GET /api/jobs/[id]     → tags: job-detail:{id}, jobs-list
- GET /api/companies     → tag: companies-list
- GET /api/metrics       → tag: metrics

revalidateTag is called in every mutation handler and at both the
success and error completion points of the async scrape IIFE, so the
3-second RESEARCHING poll on the job detail page sees status changes
within one poll interval of the Supabase write landing.

https://claude.ai/code/session_01MVGHsyipNpBEDd87TkjfiH